### PR TITLE
Test: NFT delegates during terminal migration

### DIFF
--- a/forge_tests/TestTerminal3_1.sol
+++ b/forge_tests/TestTerminal3_1.sol
@@ -502,7 +502,13 @@ contract TestTerminal31_Fork is Test {
 
         JBFundingCycle memory fundingCycle = jbFundingCycleStore.currentOf(_projectId);
         address _datasource = fundingCycle.dataSource();
-        metadata.dataSource = _datasource;
+        
+        if(_datasource != address(0)) {
+            metadata.dataSource = _datasource;
+            metadata.useDataSourceForPay = fundingCycle.useDataSourceForPay();
+            metadata.useDataSourceForRedeem = fundingCycle.useDataSourceForRedeem();
+        }
+
         metadata.allowTerminalMigration = true;
         metadata.global.allowSetTerminals = true;
 

--- a/forge_tests/TestTerminal3_1.sol
+++ b/forge_tests/TestTerminal3_1.sol
@@ -240,10 +240,21 @@ contract TestTerminal31_Fork is Test {
         metadata.useDataSourceForPay = true;
         metadata.useDataSourceForRedeem = true;
 
+        // Reconfigure with new distribution limit, in the new controller
+        fundAccessConstraints[0] = JBFundAccessConstraints({
+            terminal: jbEthTerminal3_1, 
+            token: JBTokens.ETH,
+            distributionLimit: 0, // Only overflow
+            overflowAllowance: 0,
+            distributionLimitCurrency: 2, // Currency = ETH
+            overflowAllowanceCurrency: 1
+        });
+
         uint256 _jbTokenBalanceBefore = jbTokenStore.balanceOf(_beneficiary, _projectId);
         uint256 _jbNFTBalanceBefore = IERC721(_NFTRewardDataSource).balanceOf(_beneficiary);
 
         _migrateTerminal(_projectId);
+        _migrateControllerWithGroupedsplits(_projectId, new JBGroupedSplits[](0));
 
         // pay terminal
         vm.prank(_beneficiary);
@@ -283,7 +294,7 @@ contract TestTerminal31_Fork is Test {
 
         bytes memory redemptionMetadata = abi.encode(
             bytes32(0),
-            0xb3bcbb79, // IJB721Delegate interfaceId
+            bytes4(0xb3bcbb79), // IJB721Delegate interfaceId
             redemptionId
         );
 

--- a/forge_tests/TestTerminal3_1.sol
+++ b/forge_tests/TestTerminal3_1.sol
@@ -273,6 +273,31 @@ contract TestTerminal31_Fork is Test {
 
         // Check: correct amount of NFT minted to the beneficiary?
         assertEq(IERC721(_NFTRewardDataSource).balanceOf(_beneficiary), _jbNFTBalanceBefore + 1);
+
+        // Compute the theoric tokan id minted (based on the tokenId at the time of the fork - can't be retrieved onchain)
+        uint256 tokenId = 3000000004;
+
+        // Craft the metadata: redeem the tokenId
+        uint256[] memory redemptionId = new uint256[](1);
+        redemptionId[0] = tokenId;
+
+        bytes memory redemptionMetadata = abi.encode(
+            bytes32(0),
+            0xb3bcbb79, // IJB721Delegate interfaceId
+            redemptionId
+        );
+
+        vm.prank(_beneficiary);
+        jbEthTerminal3_1.redeemTokensOf({
+            _holder: _beneficiary,
+            _projectId: _projectId,
+            _tokenCount: 0,
+            _token: address(0),
+            _minReturnedTokens: 0,
+            _beneficiary: payable(_beneficiary),
+            _memo: 'imma out of here',
+            _metadata: redemptionMetadata
+        });
     }
 
     /**

--- a/forge_tests/TestTerminal3_1.sol
+++ b/forge_tests/TestTerminal3_1.sol
@@ -344,7 +344,7 @@ contract TestTerminal31_Fork is Test {
             _metadata: redemptionMetadata
         });
 
-        // Check: we're should receive at least the ETH contributed, plus an overflow (if any)
+        // Check: should received token back, minus fee/ (reconfig from this test induces a redemption amount > contribution)
         assertGt(_received, _amount * 2);
 
         // Check: ETH actually received


### PR DESCRIPTION
# Description

Add tests for existing project with an NFT reward datasource.
The following flow is tested, using a mainnet fork of a project with an existing NFT datasource in use:
- pay the project and get 1 NFT
- migrate the terminal and controller
- pay the project and get a second NFT
- redeem and test:
- - ETH received back (minus portion withheld - fee, reserve and redemption rates - and plus share of the overflow)?
- - the 2 NFT are burned?

## Limitations & risks

This test might miss another scenario we didn't think of.

# Check-list
- [x] Tests are covering the new feature
- [x] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [x] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [x] I have run the test locally (and they pass)
- [x] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts: None