### PR TITLE
Feat/clone-project-payer

### DIFF
--- a/contracts/JBETHERC20SplitsPayer.sol
+++ b/contracts/JBETHERC20SplitsPayer.sol
@@ -90,12 +90,24 @@ contract JBETHERC20SplitsPayer is JBETHERC20ProjectPayer, ReentrancyGuard, IJBSp
   //*********************************************************************//
   // -------------------------- constructor ---------------------------- //
   //*********************************************************************//
-
-  /** 
+/**
+    @param _splitsStore A contract that stores splits for each project.
+*/
+  constructor(
+    IJBSplitsStore _splitsStore
+  )
+    JBETHERC20ProjectPayer(
+      _splitsStore.directory()
+    )
+  {
+    splitsStore = _splitsStore;
+  }
+  /**
+    @dev   The re-initialize check is done in the inherited paroject payer
+    
     @param _defaultSplitsProjectId The ID of project for which the default splits are stored.
     @param _defaultSplitsDomain The splits domain to payout when this contract receives direct payments.
     @param _defaultSplitsGroup The splits group to payout when this contract receives direct payments.
-    @param _splitsStore A contract that stores splits for each project.
     @param _defaultProjectId The ID of the project whose treasury should be forwarded the splits payer contract's received payment leftovers after distributing to the default splits group.
     @param _defaultBeneficiary The address that'll receive the project's tokens. 
     @param _defaultPreferClaimedTokens A flag indicating whether issued tokens should be automatically claimed into the beneficiary's wallet. 
@@ -104,11 +116,10 @@ contract JBETHERC20SplitsPayer is JBETHERC20ProjectPayer, ReentrancyGuard, IJBSp
     @param _preferAddToBalance  A flag indicating if received payments should call the `pay` function or the `addToBalance` function of a project.
     @param _owner The address that will own the contract.
   */
-  constructor(
+  function initialize(
     uint256 _defaultSplitsProjectId,
     uint256 _defaultSplitsDomain,
     uint256 _defaultSplitsGroup,
-    IJBSplitsStore _splitsStore,
     uint256 _defaultProjectId,
     address payable _defaultBeneficiary,
     bool _defaultPreferClaimedTokens,
@@ -116,23 +127,24 @@ contract JBETHERC20SplitsPayer is JBETHERC20ProjectPayer, ReentrancyGuard, IJBSp
     bytes memory _defaultMetadata,
     bool _preferAddToBalance,
     address _owner
-  )
-    JBETHERC20ProjectPayer(
+  ) external override {
+
+    super.initialize(
       _defaultProjectId,
       _defaultBeneficiary,
       _defaultPreferClaimedTokens,
       _defaultMemo,
       _defaultMetadata,
       _preferAddToBalance,
-      _splitsStore.directory(),
       _owner
-    )
-  {
+    );
+
     defaultSplitsProjectId = _defaultSplitsProjectId;
     defaultSplitsDomain = _defaultSplitsDomain;
     defaultSplitsGroup = _defaultSplitsGroup;
-    splitsStore = _splitsStore;
   }
+
+
 
   //*********************************************************************//
   // ------------------------- default receive ------------------------- //

--- a/contracts/JBETHERC20SplitsPayerDeployer.sol
+++ b/contracts/JBETHERC20SplitsPayerDeployer.sol
@@ -80,7 +80,6 @@ contract JBETHERC20SplitsPayerDeployer is IJBETHERC20SplitsPayerDeployer {
         _defaultSplitsProjectId,
         _domain,
         _group,
-        _splitsStore,
         _defaultProjectId,
         _defaultBeneficiary,
         _defaultPreferClaimedTokens,
@@ -102,7 +101,6 @@ contract JBETHERC20SplitsPayerDeployer is IJBETHERC20SplitsPayerDeployer {
     @param _defaultSplitsProjectId The ID of project for which the default splits are stored.
     @param _defaultSplitsDomain The splits domain to payout when this contract receives direct payments.
     @param _defaultSplitsGroup The splits group to payout when this contract receives direct payments.
-    @param _splitsStore A contract that stores splits for each project.
     @param _defaultProjectId The ID of the project whose treasury should be forwarded the splits payer contract's received payment leftovers after distributing to the default splits group.
     @param _defaultBeneficiary The address that'll receive the project's tokens when the splits payer receives payments. 
     @param _defaultPreferClaimedTokens A flag indicating whether issued tokens from the splits payer's received payments should be automatically claimed into the beneficiary's wallet. 

--- a/contracts/JBETHERC20SplitsPayerDeployer.sol
+++ b/contracts/JBETHERC20SplitsPayerDeployer.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
+import { Clones } from '@openzeppelin/contracts/proxy/Clones.sol';
+
 import './interfaces/IJBETHERC20SplitsPayerDeployer.sol';
 import './structs/JBSplit.sol';
 import './structs/JBGroupedSplits.sol';
@@ -15,6 +17,16 @@ import './JBETHERC20SplitsPayer.sol';
   IJBETHERC20SplitsPayerDeployer:  General interface for the methods in this contract that interact with the blockchain's state according to the protocol's rules.
 */
 contract JBETHERC20SplitsPayerDeployer is IJBETHERC20SplitsPayerDeployer {
+
+  address immutable implementation;
+
+  IJBSplitsStore immutable splitsStore;
+
+  constructor(IJBSplitsStore _splitsStore) {
+    implementation = address(new JBETHERC20SplitsPayer(_splitsStore));
+    splitsStore = _splitsStore;
+  }
+
   //*********************************************************************//
   // ---------------------- external transactions ---------------------- //
   //*********************************************************************//
@@ -105,7 +117,6 @@ contract JBETHERC20SplitsPayerDeployer is IJBETHERC20SplitsPayerDeployer {
     uint256 _defaultSplitsProjectId,
     uint256 _defaultSplitsDomain,
     uint256 _defaultSplitsGroup,
-    IJBSplitsStore _splitsStore,
     uint256 _defaultProjectId,
     address payable _defaultBeneficiary,
     bool _defaultPreferClaimedTokens,
@@ -114,12 +125,14 @@ contract JBETHERC20SplitsPayerDeployer is IJBETHERC20SplitsPayerDeployer {
     bool _defaultPreferAddToBalance,
     address _owner
   ) public override returns (IJBSplitsPayer splitsPayer) {
+
     // Deploy the splits payer.
-    splitsPayer = new JBETHERC20SplitsPayer(
+    splitsPayer = IJBSplitsPayer(payable(Clones.clone(implementation)));
+
+    splitsPayer.initialize(
       _defaultSplitsProjectId,
       _defaultSplitsDomain,
       _defaultSplitsGroup,
-      _splitsStore,
       _defaultProjectId,
       _defaultBeneficiary,
       _defaultPreferClaimedTokens,
@@ -134,7 +147,7 @@ contract JBETHERC20SplitsPayerDeployer is IJBETHERC20SplitsPayerDeployer {
       _defaultSplitsProjectId,
       _defaultSplitsDomain,
       _defaultSplitsGroup,
-      _splitsStore,
+      splitsStore,
       _defaultProjectId,
       _defaultBeneficiary,
       _defaultPreferClaimedTokens,

--- a/contracts/interfaces/IJBETHERC20ProjectPayerDeployer.sol
+++ b/contracts/interfaces/IJBETHERC20ProjectPayerDeployer.sol
@@ -25,7 +25,6 @@ interface IJBETHERC20ProjectPayerDeployer {
     string memory _defaultMemo,
     bytes memory _defaultMetadata,
     bool _preferAddToBalance,
-    IJBDirectory _directory,
     address _owner
   ) external returns (IJBProjectPayer projectPayer);
 }

--- a/contracts/interfaces/IJBETHERC20SplitsPayerDeployer.sol
+++ b/contracts/interfaces/IJBETHERC20SplitsPayerDeployer.sol
@@ -25,7 +25,6 @@ interface IJBETHERC20SplitsPayerDeployer {
     uint256 _defaultSplitsProjectId,
     uint256 _defaultSplitsDomain,
     uint256 _defaultSplitsGroup,
-    IJBSplitsStore _splitsStore,
     uint256 _defaultProjectId,
     address payable _defaultBeneficiary,
     bool _defaultPreferClaimedTokens,

--- a/contracts/interfaces/IJBProjectPayer.sol
+++ b/contracts/interfaces/IJBProjectPayer.sol
@@ -17,6 +17,8 @@ interface IJBProjectPayer is IERC165 {
 
   function directory() external view returns (IJBDirectory);
 
+  function projectPayerDeployer() external view returns (address);
+
   function defaultProjectId() external view returns (uint256);
 
   function defaultBeneficiary() external view returns (address payable);
@@ -28,6 +30,16 @@ interface IJBProjectPayer is IERC165 {
   function defaultMetadata() external view returns (bytes memory);
 
   function defaultPreferAddToBalance() external view returns (bool);
+
+  function initialize(
+    uint256 _defaultProjectId,
+    address payable _defaultBeneficiary,
+    bool _defaultPreferClaimedTokens,
+    string memory _defaultMemo,
+    bytes memory _defaultMetadata,
+    bool _defaultPreferAddToBalance,
+    address _owner
+  ) external;
 
   function setDefaultValues(
     uint256 _projectId,

--- a/contracts/interfaces/IJBSplitsPayer.sol
+++ b/contracts/interfaces/IJBSplitsPayer.sol
@@ -61,6 +61,19 @@ interface IJBSplitsPayer is IERC165 {
 
   function splitsStore() external view returns (IJBSplitsStore);
 
+  function initialize(
+    uint256 _defaultSplitsProjectId,
+    uint256 _defaultSplitsDomain,
+    uint256 _defaultSplitsGroup,
+    uint256 _defaultProjectId,
+    address payable _defaultBeneficiary,
+    bool _defaultPreferClaimedTokens,
+    string memory _defaultMemo,
+    bytes memory _defaultMetadata,
+    bool _preferAddToBalance,
+    address _owner
+  ) external;
+
   function setDefaultSplitsReference(
     uint256 _projectId,
     uint256 _domain,

--- a/forge_tests/TestEIP165.sol
+++ b/forge_tests/TestEIP165.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.6;
 import "./helpers/TestBaseWorkflow.sol";
 import "@juicebox/JBReconfigurationBufferBallot.sol";
 import "@juicebox/JBETHERC20SplitsPayer.sol";
+import "@juicebox/JBETHERC20SplitsPayerDeployer.sol";
 
 contract TestEIP165_Local is TestBaseWorkflow {
     bytes4 constant notSupportedInterface = 0xffffffff;
@@ -112,19 +113,24 @@ contract TestEIP165_Local is TestBaseWorkflow {
     }
 
     function testJBETHERC20SplitsPayer() public {
-        JBETHERC20SplitsPayer splitsPayer = new JBETHERC20SplitsPayer(
-      splitsProjectID,
-      splitsDomain,
-      splitsGroup,
-      jbSplitsStore(),
-      projectId,
-      splitsBeneficiary,
-      splitsPreferClaimedTokens,
-      splitsMemo,
-      splitsMetadata,
-      splitsPreferAddToBalance,
-      splitsOwner
-    );
+      
+        JBETHERC20SplitsPayerDeployer deployer = new JBETHERC20SplitsPayerDeployer(jbSplitsStore());
+
+        JBETHERC20SplitsPayer splitsPayer = JBETHERC20SplitsPayer(
+            payable(
+                address(
+                deployer.deploySplitsPayer(
+                    splitsProjectID,
+                    splitsDomain,
+                    splitsGroup,
+                    projectId,
+                    splitsBeneficiary,
+                    splitsPreferClaimedTokens,
+                    splitsMemo,
+                    splitsMetadata,
+                    splitsPreferAddToBalance,
+                    splitsOwner
+        ))));
 
         // Should support these interfaces
         assertTrue(splitsPayer.supportsInterface(type(IERC165).interfaceId));

--- a/test/jb_eth_erc20_project_payer/pay.test.js
+++ b/test/jb_eth_erc20_project_payer/pay.test.js
@@ -154,18 +154,24 @@ describe('JBETHERC20ProjectPayer::pay(...)', function () {
   });
 
   it(`Should pay and use the caller if no beneficiary or default beneficiary is set`, async function () {
-    const { owner, caller, jbProjectPayerFactory, mockJbDirectory, mockJbTerminal } = await setup();
+    const { owner, caller, deployer, jbProjectPayerFactory, mockJbDirectory, mockJbTerminal } =
+      await setup();
 
-    let _jbProjectPayer = await jbProjectPayerFactory.deploy(
-      INITIAL_PROJECT_ID,
-      ethers.constants.AddressZero,
-      INITIAL_PREFER_CLAIMED_TOKENS,
-      INITIAL_MEMO,
-      INITIAL_METADATA,
-      INITIAL_PREFER_ADD_TO_BALANCE,
-      mockJbDirectory.address,
-      owner.address,
-    );
+    let _jbProjectPayer = await jbProjectPayerFactory
+      .connect(deployer)
+      .deploy(mockJbDirectory.address);
+
+    await _jbProjectPayer
+      .connect(deployer)
+      .initialize(
+        INITIAL_PROJECT_ID,
+        ethers.constants.AddressZero,
+        INITIAL_PREFER_CLAIMED_TOKENS,
+        INITIAL_MEMO,
+        INITIAL_METADATA,
+        INITIAL_PREFER_ADD_TO_BALANCE,
+        owner.address,
+      );
 
     await mockJbDirectory.mock.primaryTerminalOf
       .withArgs(PROJECT_ID, ethToken)

--- a/test/jb_eth_erc20_project_payer_deployer/add_to_balance.test.js
+++ b/test/jb_eth_erc20_project_payer_deployer/add_to_balance.test.js
@@ -9,7 +9,7 @@ import jbTerminal from '../../artifacts/contracts/abstract/JBPayoutRedemptionPay
 import ierc20 from '../../artifacts/@openzeppelin/contracts/token/ERC20/ERC20.sol/ERC20.json';
 import errors from '../helpers/errors.json';
 
-describe('JBETHERC20ProjectPayer::addToBalanceOf(...)', function () {
+describe('JBETHERC20ProjectPayer via Proxy::addToBalanceOf(...)', function () {
   const INITIAL_PROJECT_ID = 1;
   const INITIAL_BENEFICIARY = ethers.Wallet.createRandom().address;
   const INITIAL_PREFER_CLAIMED_TOKENS = false;
@@ -40,14 +40,16 @@ describe('JBETHERC20ProjectPayer::addToBalanceOf(...)', function () {
     let mockJbTerminal = await deployMockContract(deployer, jbTerminal.abi);
     let mockToken = await smock.fake(ierc20.abi);
 
-    let jbProjectPayerFactory = await ethers.getContractFactory('JBETHERC20ProjectPayer');
-    let jbProjectPayer = await jbProjectPayerFactory
-      .connect(deployer)
-      .deploy(mockJbDirectory.address);
+    let jbProjectPayerDeployerFactory = await ethers.getContractFactory(
+      'JBETHERC20ProjectPayerDeployer',
+    );
+    let jbProjectPayerDeployer = await jbProjectPayerDeployerFactory.deploy(
+      mockJbDirectory.address,
+    );
 
-    await jbProjectPayer
-      .connect(deployer)
-      .initialize(
+    let jbProjectPayerFactory = await ethers.getContractFactory('JBETHERC20ProjectPayer');
+    let jbProjectPayer = jbProjectPayerFactory.attach(
+      await jbProjectPayerDeployer.callStatic.deployProjectPayer(
         INITIAL_PROJECT_ID,
         INITIAL_BENEFICIARY,
         INITIAL_PREFER_CLAIMED_TOKENS,
@@ -55,7 +57,18 @@ describe('JBETHERC20ProjectPayer::addToBalanceOf(...)', function () {
         INITIAL_METADATA,
         INITIAL_PREFER_ADD_TO_BALANCE,
         owner.address,
-      );
+      ),
+    );
+
+    await jbProjectPayerDeployer.deployProjectPayer(
+      INITIAL_PROJECT_ID,
+      INITIAL_BENEFICIARY,
+      INITIAL_PREFER_CLAIMED_TOKENS,
+      INITIAL_MEMO,
+      INITIAL_METADATA,
+      INITIAL_PREFER_ADD_TO_BALANCE,
+      owner.address,
+    );
 
     return {
       deployer,

--- a/test/jb_eth_erc20_project_payer_deployer/deploy_project_payer.test.js
+++ b/test/jb_eth_erc20_project_payer_deployer/deploy_project_payer.test.js
@@ -18,10 +18,25 @@ describe('JBProjectPayerDeployer::deployProjectPayer(...)', function () {
 
     const mockJbDirectory = await deployMockContract(deployer, jbDirectory.abi);
 
-    const jbProjectPayerDeployerFactory = await ethers.getContractFactory(
+    let jbProjectPayerDeployerFactory = await ethers.getContractFactory(
       'JBETHERC20ProjectPayerDeployer',
     );
-    const jbProjectPayerDeployer = await jbProjectPayerDeployerFactory.deploy();
+    let jbProjectPayerDeployer = await jbProjectPayerDeployerFactory.deploy(
+      mockJbDirectory.address,
+    );
+
+    let jbProjectPayerFactory = await ethers.getContractFactory('JBETHERC20ProjectPayer');
+    let jbProjectPayer = jbProjectPayerFactory.attach(
+      await jbProjectPayerDeployer.callStatic.deployProjectPayer(
+        INITIAL_PROJECT_ID,
+        INITIAL_BENEFICIARY,
+        INITIAL_PREFER_CLAIMED_TOKENS,
+        INITIAL_MEMO,
+        INITIAL_METADATA,
+        INITIAL_PREFER_ADD_TO_BALANCE,
+        owner.address,
+      ),
+    );
 
     return {
       owner,
@@ -48,7 +63,6 @@ describe('JBProjectPayerDeployer::deployProjectPayer(...)', function () {
         INITIAL_MEMO,
         INITIAL_METADATA,
         INITIAL_PREFER_ADD_TO_BALANCE,
-        mockJbDirectory.address,
         owner.address,
       );
 

--- a/test/jb_eth_erc20_project_payer_deployer/pay.test.js
+++ b/test/jb_eth_erc20_project_payer_deployer/pay.test.js
@@ -79,6 +79,7 @@ describe('JBETHERC20ProjectPayer via Proxy::pay(...)', function () {
       mockJbDirectory,
       mockJbTerminal,
       jbProjectPayer,
+      jbProjectPayerDeployer,
       jbProjectPayerFactory,
     };
   }
@@ -167,7 +168,14 @@ describe('JBETHERC20ProjectPayer via Proxy::pay(...)', function () {
   });
 
   it(`Should pay and use the caller if no beneficiary or default beneficiary is set`, async function () {
-    const { owner, caller, jbProjectPayerFactory, mockJbDirectory, mockJbTerminal } = await setup();
+    const {
+      owner,
+      caller,
+      jbProjectPayerFactory,
+      jbProjectPayerDeployer,
+      mockJbDirectory,
+      mockJbTerminal,
+    } = await setup();
 
     let _jbProjectPayer = jbProjectPayerFactory.attach(
       await jbProjectPayerDeployer.callStatic.deployProjectPayer(

--- a/test/jb_eth_erc20_project_payer_deployer/pay.test.js
+++ b/test/jb_eth_erc20_project_payer_deployer/pay.test.js
@@ -9,7 +9,7 @@ import jbTerminal from '../../artifacts/contracts/abstract/JBPayoutRedemptionPay
 import ierc20 from '../../artifacts/@openzeppelin/contracts/token/ERC20/ERC20.sol/ERC20.json';
 import errors from '../helpers/errors.json';
 
-describe('JBETHERC20ProjectPayer::pay(...)', function () {
+describe('JBETHERC20ProjectPayer via Proxy::pay(...)', function () {
   const INITIAL_PROJECT_ID = 1;
   const INITIAL_BENEFICIARY = ethers.Wallet.createRandom().address;
   const INITIAL_PREFER_CLAIMED_TOKENS = false;
@@ -40,14 +40,16 @@ describe('JBETHERC20ProjectPayer::pay(...)', function () {
     let mockJbTerminal = await deployMockContract(deployer, jbTerminal.abi);
     let mockToken = await smock.fake(ierc20.abi);
 
-    let jbProjectPayerFactory = await ethers.getContractFactory('JBETHERC20ProjectPayer');
-    let jbProjectPayer = await jbProjectPayerFactory
-      .connect(deployer)
-      .deploy(mockJbDirectory.address);
+    let jbProjectPayerDeployerFactory = await ethers.getContractFactory(
+      'JBETHERC20ProjectPayerDeployer',
+    );
+    let jbProjectPayerDeployer = await jbProjectPayerDeployerFactory.deploy(
+      mockJbDirectory.address,
+    );
 
-    await jbProjectPayer
-      .connect(deployer)
-      .initialize(
+    let jbProjectPayerFactory = await ethers.getContractFactory('JBETHERC20ProjectPayer');
+    let jbProjectPayer = jbProjectPayerFactory.attach(
+      await jbProjectPayerDeployer.callStatic.deployProjectPayer(
         INITIAL_PROJECT_ID,
         INITIAL_BENEFICIARY,
         INITIAL_PREFER_CLAIMED_TOKENS,
@@ -55,7 +57,18 @@ describe('JBETHERC20ProjectPayer::pay(...)', function () {
         INITIAL_METADATA,
         INITIAL_PREFER_ADD_TO_BALANCE,
         owner.address,
-      );
+      ),
+    );
+
+    await jbProjectPayerDeployer.deployProjectPayer(
+      INITIAL_PROJECT_ID,
+      INITIAL_BENEFICIARY,
+      INITIAL_PREFER_CLAIMED_TOKENS,
+      INITIAL_MEMO,
+      INITIAL_METADATA,
+      INITIAL_PREFER_ADD_TO_BALANCE,
+      owner.address,
+    );
 
     return {
       deployer,
@@ -156,14 +169,25 @@ describe('JBETHERC20ProjectPayer::pay(...)', function () {
   it(`Should pay and use the caller if no beneficiary or default beneficiary is set`, async function () {
     const { owner, caller, jbProjectPayerFactory, mockJbDirectory, mockJbTerminal } = await setup();
 
-    let _jbProjectPayer = await jbProjectPayerFactory.deploy(
+    let _jbProjectPayer = jbProjectPayerFactory.attach(
+      await jbProjectPayerDeployer.callStatic.deployProjectPayer(
+        INITIAL_PROJECT_ID,
+        ethers.constants.AddressZero,
+        INITIAL_PREFER_CLAIMED_TOKENS,
+        INITIAL_MEMO,
+        INITIAL_METADATA,
+        INITIAL_PREFER_ADD_TO_BALANCE,
+        owner.address,
+      ),
+    );
+
+    await jbProjectPayerDeployer.deployProjectPayer(
       INITIAL_PROJECT_ID,
       ethers.constants.AddressZero,
       INITIAL_PREFER_CLAIMED_TOKENS,
       INITIAL_MEMO,
       INITIAL_METADATA,
       INITIAL_PREFER_ADD_TO_BALANCE,
-      mockJbDirectory.address,
       owner.address,
     );
 

--- a/test/jb_eth_erc20_splits_payer/add_to_balance.test.js
+++ b/test/jb_eth_erc20_splits_payer/add_to_balance.test.js
@@ -66,25 +66,29 @@ describe('JBETHERC20SplitsPayer::addToBalanceOf(...)', function () {
     let mockJbTerminal = await deployMockContract(deployer, jbTerminal.abi);
     let mockToken = await smock.fake(ierc20.abi);
 
+    await mockJbSplitsStore.mock.directory.returns(mockJbDirectory.address);
+
     let jbSplitsPayerFactory = await ethers.getContractFactory(
       'contracts/JBETHERC20SplitsPayer.sol:JBETHERC20SplitsPayer',
     );
+    let jbSplitsPayer = await jbSplitsPayerFactory
+      .connect(deployer)
+      .deploy(mockJbSplitsStore.address);
 
-    await mockJbSplitsStore.mock.directory.returns(mockJbDirectory.address);
-
-    let jbSplitsPayer = await jbSplitsPayerFactory.deploy(
-      DEFAULT_SPLITS_PROJECT_ID,
-      DEFAULT_SPLITS_DOMAIN,
-      DEFAULT_SPLITS_GROUP,
-      mockJbSplitsStore.address,
-      DEFAULT_PROJECT_ID,
-      DEFAULT_BENEFICIARY,
-      DEFAULT_PREFER_CLAIMED_TOKENS,
-      DEFAULT_MEMO,
-      DEFAULT_METADATA,
-      PREFER_ADD_TO_BALANCE,
-      owner.address,
-    );
+    await jbSplitsPayer
+      .connect(deployer)
+      ['initialize(uint256,uint256,uint256,uint256,address,bool,string,bytes,bool,address)'](
+        DEFAULT_SPLITS_PROJECT_ID,
+        DEFAULT_SPLITS_DOMAIN,
+        DEFAULT_SPLITS_GROUP,
+        DEFAULT_PROJECT_ID,
+        DEFAULT_BENEFICIARY,
+        DEFAULT_PREFER_CLAIMED_TOKENS,
+        DEFAULT_MEMO,
+        DEFAULT_METADATA,
+        PREFER_ADD_TO_BALANCE,
+        owner.address,
+      );
 
     return {
       beneficiaryOne,
@@ -726,23 +730,28 @@ describe('JBETHERC20SplitsPayer::addToBalanceOf(...)', function () {
   });
 
   it(`Should send fund directly to the caller, if no allocator, project ID, beneficiary or default beneficiary is set,  and emit event`, async function () {
-    const { caller, jbSplitsPayerFactory, mockJbSplitsStore, owner } = await setup();
+    const { caller, deployer, jbSplitsPayerFactory, mockJbSplitsStore, owner } = await setup();
 
     let splits = makeSplits();
 
-    let jbSplitsPayerWithoutDefaultBeneficiary = await jbSplitsPayerFactory.deploy(
-      DEFAULT_SPLITS_PROJECT_ID,
-      DEFAULT_SPLITS_DOMAIN,
-      DEFAULT_SPLITS_GROUP,
-      mockJbSplitsStore.address,
-      DEFAULT_PROJECT_ID,
-      ethers.constants.AddressZero,
-      DEFAULT_PREFER_CLAIMED_TOKENS,
-      DEFAULT_MEMO,
-      DEFAULT_METADATA,
-      PREFER_ADD_TO_BALANCE,
-      owner.address,
-    );
+    let jbSplitsPayerWithoutDefaultBeneficiary = await jbSplitsPayerFactory
+      .connect(deployer)
+      .deploy(mockJbSplitsStore.address);
+
+    await jbSplitsPayerWithoutDefaultBeneficiary
+      .connect(deployer)
+      ['initialize(uint256,uint256,uint256,uint256,address,bool,string,bytes,bool,address)'](
+        DEFAULT_SPLITS_PROJECT_ID,
+        DEFAULT_SPLITS_DOMAIN,
+        DEFAULT_SPLITS_GROUP,
+        DEFAULT_PROJECT_ID,
+        ethers.constants.AddressZero,
+        DEFAULT_PREFER_CLAIMED_TOKENS,
+        DEFAULT_MEMO,
+        DEFAULT_METADATA,
+        PREFER_ADD_TO_BALANCE,
+        owner.address,
+      );
 
     await mockJbSplitsStore.mock.splitsOf
       .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
@@ -901,6 +910,7 @@ describe('JBETHERC20SplitsPayer::addToBalanceOf(...)', function () {
   it(`Should send eth leftover to default beneficiary if no project id set and emit event`, async function () {
     const {
       caller,
+      deployer,
       owner,
       jbSplitsPayerFactory,
       mockJbSplitsStore,
@@ -910,19 +920,24 @@ describe('JBETHERC20SplitsPayer::addToBalanceOf(...)', function () {
       beneficiaryThree,
     } = await setup();
 
-    let jbSplitsPayer = await jbSplitsPayerFactory.deploy(
-      DEFAULT_SPLITS_PROJECT_ID,
-      DEFAULT_SPLITS_DOMAIN,
-      DEFAULT_SPLITS_GROUP,
-      mockJbSplitsStore.address,
-      DEFAULT_PROJECT_ID,
-      beneficiaryThree.address,
-      DEFAULT_PREFER_CLAIMED_TOKENS,
-      DEFAULT_MEMO,
-      DEFAULT_METADATA,
-      PREFER_ADD_TO_BALANCE,
-      owner.address,
-    );
+    let jbSplitsPayer = await jbSplitsPayerFactory
+      .connect(deployer)
+      .deploy(mockJbSplitsStore.address);
+
+    await jbSplitsPayer
+      .connect(deployer)
+      ['initialize(uint256,uint256,uint256,uint256,address,bool,string,bytes,bool,address)'](
+        DEFAULT_SPLITS_PROJECT_ID,
+        DEFAULT_SPLITS_DOMAIN,
+        DEFAULT_SPLITS_GROUP,
+        DEFAULT_PROJECT_ID,
+        beneficiaryThree.address,
+        DEFAULT_PREFER_CLAIMED_TOKENS,
+        DEFAULT_MEMO,
+        DEFAULT_METADATA,
+        PREFER_ADD_TO_BALANCE,
+        owner.address,
+      );
 
     // 50% to beneficiaries
     let splits = makeSplits({
@@ -974,6 +989,7 @@ describe('JBETHERC20SplitsPayer::addToBalanceOf(...)', function () {
   it(`Should send erc20 leftover to default beneficiary if no project id set and emit event`, async function () {
     const {
       caller,
+      deployer,
       owner,
       jbSplitsPayerFactory,
       mockToken,
@@ -983,19 +999,24 @@ describe('JBETHERC20SplitsPayer::addToBalanceOf(...)', function () {
       beneficiaryThree,
     } = await setup();
 
-    let jbSplitsPayer = await jbSplitsPayerFactory.deploy(
-      DEFAULT_SPLITS_PROJECT_ID,
-      DEFAULT_SPLITS_DOMAIN,
-      DEFAULT_SPLITS_GROUP,
-      mockJbSplitsStore.address,
-      DEFAULT_PROJECT_ID,
-      beneficiaryThree.address,
-      DEFAULT_PREFER_CLAIMED_TOKENS,
-      DEFAULT_MEMO,
-      DEFAULT_METADATA,
-      PREFER_ADD_TO_BALANCE,
-      owner.address,
-    );
+    let jbSplitsPayer = await jbSplitsPayerFactory
+      .connect(deployer)
+      .deploy(mockJbSplitsStore.address);
+
+    await jbSplitsPayer
+      .connect(deployer)
+      ['initialize(uint256,uint256,uint256,uint256,address,bool,string,bytes,bool,address)'](
+        DEFAULT_SPLITS_PROJECT_ID,
+        DEFAULT_SPLITS_DOMAIN,
+        DEFAULT_SPLITS_GROUP,
+        DEFAULT_PROJECT_ID,
+        beneficiaryThree.address,
+        DEFAULT_PREFER_CLAIMED_TOKENS,
+        DEFAULT_MEMO,
+        DEFAULT_METADATA,
+        PREFER_ADD_TO_BALANCE,
+        owner.address,
+      );
 
     // 50% to beneficiaries
     let splits = makeSplits({
@@ -1051,6 +1072,7 @@ describe('JBETHERC20SplitsPayer::addToBalanceOf(...)', function () {
   it(`Should send eth leftover to the caller if no project id nor default beneficiary is set and emit event`, async function () {
     const {
       caller,
+      deployer,
       owner,
       jbSplitsPayerFactory,
       mockJbDirectory,
@@ -1061,19 +1083,24 @@ describe('JBETHERC20SplitsPayer::addToBalanceOf(...)', function () {
       beneficiaryThree,
     } = await setup();
 
-    let jbSplitsPayer = await jbSplitsPayerFactory.deploy(
-      DEFAULT_SPLITS_PROJECT_ID,
-      DEFAULT_SPLITS_DOMAIN,
-      DEFAULT_SPLITS_GROUP,
-      mockJbSplitsStore.address,
-      DEFAULT_PROJECT_ID,
-      ethers.constants.AddressZero,
-      DEFAULT_PREFER_CLAIMED_TOKENS,
-      DEFAULT_MEMO,
-      DEFAULT_METADATA,
-      PREFER_ADD_TO_BALANCE,
-      owner.address,
-    );
+    let jbSplitsPayer = await jbSplitsPayerFactory
+      .connect(deployer)
+      .deploy(mockJbSplitsStore.address);
+
+    await jbSplitsPayer
+      .connect(deployer)
+      ['initialize(uint256,uint256,uint256,uint256,address,bool,string,bytes,bool,address)'](
+        DEFAULT_SPLITS_PROJECT_ID,
+        DEFAULT_SPLITS_DOMAIN,
+        DEFAULT_SPLITS_GROUP,
+        DEFAULT_PROJECT_ID,
+        ethers.constants.AddressZero,
+        DEFAULT_PREFER_CLAIMED_TOKENS,
+        DEFAULT_MEMO,
+        DEFAULT_METADATA,
+        PREFER_ADD_TO_BALANCE,
+        owner.address,
+      );
 
     // 50% to beneficiaries
     let splits = makeSplits({
@@ -1124,6 +1151,7 @@ describe('JBETHERC20SplitsPayer::addToBalanceOf(...)', function () {
   it(`Should send erc20 leftover to the caller if no project id nor beneficiary is set and emit event`, async function () {
     const {
       caller,
+      deployer,
       owner,
       jbSplitsPayerFactory,
       mockJbSplitsStore,
@@ -1133,19 +1161,24 @@ describe('JBETHERC20SplitsPayer::addToBalanceOf(...)', function () {
       beneficiaryThree,
     } = await setup();
 
-    let jbSplitsPayer = await jbSplitsPayerFactory.deploy(
-      DEFAULT_SPLITS_PROJECT_ID,
-      DEFAULT_SPLITS_DOMAIN,
-      DEFAULT_SPLITS_GROUP,
-      mockJbSplitsStore.address,
-      DEFAULT_PROJECT_ID,
-      ethers.constants.AddressZero,
-      DEFAULT_PREFER_CLAIMED_TOKENS,
-      DEFAULT_MEMO,
-      DEFAULT_METADATA,
-      PREFER_ADD_TO_BALANCE,
-      owner.address,
-    );
+    let jbSplitsPayer = await jbSplitsPayerFactory
+      .connect(deployer)
+      .deploy(mockJbSplitsStore.address);
+
+    await jbSplitsPayer
+      .connect(deployer)
+      ['initialize(uint256,uint256,uint256,uint256,address,bool,string,bytes,bool,address)'](
+        DEFAULT_SPLITS_PROJECT_ID,
+        DEFAULT_SPLITS_DOMAIN,
+        DEFAULT_SPLITS_GROUP,
+        DEFAULT_PROJECT_ID,
+        ethers.constants.AddressZero,
+        DEFAULT_PREFER_CLAIMED_TOKENS,
+        DEFAULT_MEMO,
+        DEFAULT_METADATA,
+        PREFER_ADD_TO_BALANCE,
+        owner.address,
+      );
 
     // 50% to beneficiaries
     let splits = makeSplits({

--- a/test/jb_eth_erc20_splits_payer/pay.test.js
+++ b/test/jb_eth_erc20_splits_payer/pay.test.js
@@ -66,25 +66,29 @@ describe('JBETHERC20SplitsPayer::pay(...)', function () {
     let mockJbTerminal = await deployMockContract(deployer, jbTerminal.abi);
     let mockToken = await smock.fake(ierc20.abi);
 
+    await mockJbSplitsStore.mock.directory.returns(mockJbDirectory.address);
+
     let jbSplitsPayerFactory = await ethers.getContractFactory(
       'contracts/JBETHERC20SplitsPayer.sol:JBETHERC20SplitsPayer',
     );
+    let jbSplitsPayer = await jbSplitsPayerFactory
+      .connect(deployer)
+      .deploy(mockJbSplitsStore.address);
 
-    await mockJbSplitsStore.mock.directory.returns(mockJbDirectory.address);
-
-    let jbSplitsPayer = await jbSplitsPayerFactory.deploy(
-      DEFAULT_SPLITS_PROJECT_ID,
-      DEFAULT_SPLITS_DOMAIN,
-      DEFAULT_SPLITS_GROUP,
-      mockJbSplitsStore.address,
-      DEFAULT_PROJECT_ID,
-      DEFAULT_BENEFICIARY,
-      DEFAULT_PREFER_CLAIMED_TOKENS,
-      DEFAULT_MEMO,
-      DEFAULT_METADATA,
-      PREFER_ADD_TO_BALANCE,
-      owner.address,
-    );
+    await jbSplitsPayer
+      .connect(deployer)
+      ['initialize(uint256,uint256,uint256,uint256,address,bool,string,bytes,bool,address)'](
+        DEFAULT_SPLITS_PROJECT_ID,
+        DEFAULT_SPLITS_DOMAIN,
+        DEFAULT_SPLITS_GROUP,
+        DEFAULT_PROJECT_ID,
+        DEFAULT_BENEFICIARY,
+        DEFAULT_PREFER_CLAIMED_TOKENS,
+        DEFAULT_MEMO,
+        DEFAULT_METADATA,
+        PREFER_ADD_TO_BALANCE,
+        owner.address,
+      );
 
     return {
       beneficiaryOne,
@@ -760,23 +764,28 @@ describe('JBETHERC20SplitsPayer::pay(...)', function () {
   });
 
   it(`Should send fund directly to the caller, if no allocator, project ID, beneficiary or default beneficiary is set, and emit event`, async function () {
-    const { caller, jbSplitsPayerFactory, mockJbSplitsStore, owner } = await setup();
+    const { caller, deployer, jbSplitsPayerFactory, mockJbSplitsStore, owner } = await setup();
 
     let splits = makeSplits();
 
-    let jbSplitsPayerWithoutDefaultBeneficiary = await jbSplitsPayerFactory.deploy(
-      DEFAULT_SPLITS_PROJECT_ID,
-      DEFAULT_SPLITS_DOMAIN,
-      DEFAULT_SPLITS_GROUP,
-      mockJbSplitsStore.address,
-      DEFAULT_PROJECT_ID,
-      ethers.constants.AddressZero,
-      DEFAULT_PREFER_CLAIMED_TOKENS,
-      DEFAULT_MEMO,
-      DEFAULT_METADATA,
-      PREFER_ADD_TO_BALANCE,
-      owner.address,
-    );
+    let jbSplitsPayerWithoutDefaultBeneficiary = await jbSplitsPayerFactory
+      .connect(deployer)
+      .deploy(mockJbSplitsStore.address);
+
+    await jbSplitsPayerWithoutDefaultBeneficiary
+      .connect(deployer)
+      ['initialize(uint256,uint256,uint256,uint256,address,bool,string,bytes,bool,address)'](
+        DEFAULT_SPLITS_PROJECT_ID,
+        DEFAULT_SPLITS_DOMAIN,
+        DEFAULT_SPLITS_GROUP,
+        DEFAULT_PROJECT_ID,
+        ethers.constants.AddressZero,
+        DEFAULT_PREFER_CLAIMED_TOKENS,
+        DEFAULT_MEMO,
+        DEFAULT_METADATA,
+        PREFER_ADD_TO_BALANCE,
+        owner.address,
+      );
 
     await mockJbSplitsStore.mock.splitsOf
       .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
@@ -1161,6 +1170,7 @@ describe('JBETHERC20SplitsPayer::pay(...)', function () {
   it(`Should send eth leftover to the caller if no project id nor beneficiary is set and emit event`, async function () {
     const {
       caller,
+      deployer,
       owner,
       jbSplitsPayerFactory,
       mockJbDirectory,
@@ -1178,19 +1188,24 @@ describe('JBETHERC20SplitsPayer::pay(...)', function () {
       percent: maxSplitsPercent.div('4'),
     });
 
-    let jbSplitsPayerWithoutDefaultBeneficiary = await jbSplitsPayerFactory.deploy(
-      DEFAULT_SPLITS_PROJECT_ID,
-      DEFAULT_SPLITS_DOMAIN,
-      DEFAULT_SPLITS_GROUP,
-      mockJbSplitsStore.address,
-      DEFAULT_PROJECT_ID,
-      ethers.constants.AddressZero,
-      DEFAULT_PREFER_CLAIMED_TOKENS,
-      DEFAULT_MEMO,
-      DEFAULT_METADATA,
-      PREFER_ADD_TO_BALANCE,
-      owner.address,
-    );
+    let jbSplitsPayerWithoutDefaultBeneficiary = await jbSplitsPayerFactory
+      .connect(deployer)
+      .deploy(mockJbSplitsStore.address);
+
+    await jbSplitsPayerWithoutDefaultBeneficiary
+      .connect(deployer)
+      ['initialize(uint256,uint256,uint256,uint256,address,bool,string,bytes,bool,address)'](
+        DEFAULT_SPLITS_PROJECT_ID,
+        DEFAULT_SPLITS_DOMAIN,
+        DEFAULT_SPLITS_GROUP,
+        DEFAULT_PROJECT_ID,
+        ethers.constants.AddressZero,
+        DEFAULT_PREFER_CLAIMED_TOKENS,
+        DEFAULT_MEMO,
+        DEFAULT_METADATA,
+        PREFER_ADD_TO_BALANCE,
+        owner.address,
+      );
 
     await mockJbSplitsStore.mock.splitsOf
       .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
@@ -1247,6 +1262,7 @@ describe('JBETHERC20SplitsPayer::pay(...)', function () {
   it(`Should send erc20 leftover to the caller if no project id nor beneficiary is set and emit event`, async function () {
     const {
       caller,
+      deployer,
       owner,
       jbSplitsPayerFactory,
       mockJbSplitsStore,
@@ -1263,19 +1279,24 @@ describe('JBETHERC20SplitsPayer::pay(...)', function () {
       percent: maxSplitsPercent.div('4'),
     });
 
-    let jbSplitsPayerWithoutDefaultBeneficiary = await jbSplitsPayerFactory.deploy(
-      DEFAULT_SPLITS_PROJECT_ID,
-      DEFAULT_SPLITS_DOMAIN,
-      DEFAULT_SPLITS_GROUP,
-      mockJbSplitsStore.address,
-      DEFAULT_PROJECT_ID,
-      ethers.constants.AddressZero,
-      DEFAULT_PREFER_CLAIMED_TOKENS,
-      DEFAULT_MEMO,
-      DEFAULT_METADATA,
-      PREFER_ADD_TO_BALANCE,
-      owner.address,
-    );
+    let jbSplitsPayerWithoutDefaultBeneficiary = await jbSplitsPayerFactory
+      .connect(deployer)
+      .deploy(mockJbSplitsStore.address);
+
+    await jbSplitsPayerWithoutDefaultBeneficiary
+      .connect(deployer)
+      ['initialize(uint256,uint256,uint256,uint256,address,bool,string,bytes,bool,address)'](
+        DEFAULT_SPLITS_PROJECT_ID,
+        DEFAULT_SPLITS_DOMAIN,
+        DEFAULT_SPLITS_GROUP,
+        DEFAULT_PROJECT_ID,
+        ethers.constants.AddressZero,
+        DEFAULT_PREFER_CLAIMED_TOKENS,
+        DEFAULT_MEMO,
+        DEFAULT_METADATA,
+        PREFER_ADD_TO_BALANCE,
+        owner.address,
+      );
 
     // Transfer to splitsPayer
     mockToken.balanceOf.returnsAtCall(0, 0);

--- a/test/jb_eth_erc20_splits_payer/set_default_splits.test.js
+++ b/test/jb_eth_erc20_splits_payer/set_default_splits.test.js
@@ -28,25 +28,30 @@ describe('JBETHERC20SplitsPayer::setDefaultSplits()', function () {
 
     let mockJbDirectory = await deployMockContract(deployer, jbDirectory.abi);
     let mockJbSplitsStore = await deployMockContract(deployer, jbSplitsStore.abi);
-    let jbSplitsPayerFactory = await ethers.getContractFactory(
-      'contracts/JBETHERC20SplitsPayer.sol:JBETHERC20SplitsPayer',
-    );
 
     await mockJbSplitsStore.mock.directory.returns(mockJbDirectory.address);
 
-    let jbSplitsPayer = await jbSplitsPayerFactory.deploy(
-      DEFAULT_SPLITS_PROJECT_ID,
-      DEFAULT_SPLITS_DOMAIN,
-      DEFAULT_SPLITS_GROUP,
-      mockJbSplitsStore.address,
-      DEFAULT_PROJECT_ID,
-      DEFAULT_BENEFICIARY,
-      DEFAULT_PREFER_CLAIMED_TOKENS,
-      DEFAULT_MEMO,
-      DEFAULT_METADATA,
-      PREFER_ADD_TO_BALANCE,
-      owner.address,
+    let jbSplitsPayerFactory = await ethers.getContractFactory(
+      'contracts/JBETHERC20SplitsPayer.sol:JBETHERC20SplitsPayer',
     );
+    let jbSplitsPayer = await jbSplitsPayerFactory
+      .connect(deployer)
+      .deploy(mockJbSplitsStore.address);
+
+    await jbSplitsPayer
+      .connect(deployer)
+      ['initialize(uint256,uint256,uint256,uint256,address,bool,string,bytes,bool,address)'](
+        DEFAULT_SPLITS_PROJECT_ID,
+        DEFAULT_SPLITS_DOMAIN,
+        DEFAULT_SPLITS_GROUP,
+        DEFAULT_PROJECT_ID,
+        DEFAULT_BENEFICIARY,
+        DEFAULT_PREFER_CLAIMED_TOKENS,
+        DEFAULT_MEMO,
+        DEFAULT_METADATA,
+        PREFER_ADD_TO_BALANCE,
+        owner.address,
+      );
 
     return {
       deployer,

--- a/test/jb_eth_erc20_splits_payer/set_default_splits_reference.test.js
+++ b/test/jb_eth_erc20_splits_payer/set_default_splits_reference.test.js
@@ -26,25 +26,30 @@ describe('JBETHERC20SplitsPayer::setDefaultSplitsReference()', function () {
 
     let mockJbDirectory = await deployMockContract(deployer, jbDirectory.abi);
     let mockJbSplitsStore = await deployMockContract(deployer, jbSplitsStore.abi);
-    let jbSplitsPayerFactory = await ethers.getContractFactory(
-      'contracts/JBETHERC20SplitsPayer.sol:JBETHERC20SplitsPayer',
-    );
 
     await mockJbSplitsStore.mock.directory.returns(mockJbDirectory.address);
 
-    let jbSplitsPayer = await jbSplitsPayerFactory.deploy(
-      DEFAULT_SPLITS_PROJECT_ID,
-      DEFAULT_SPLITS_DOMAIN,
-      DEFAULT_SPLITS_GROUP,
-      mockJbSplitsStore.address,
-      DEFAULT_PROJECT_ID,
-      DEFAULT_BENEFICIARY,
-      DEFAULT_PREFER_CLAIMED_TOKENS,
-      DEFAULT_MEMO,
-      DEFAULT_METADATA,
-      PREFER_ADD_TO_BALANCE,
-      owner.address,
+    let jbSplitsPayerFactory = await ethers.getContractFactory(
+      'contracts/JBETHERC20SplitsPayer.sol:JBETHERC20SplitsPayer',
     );
+    let jbSplitsPayer = await jbSplitsPayerFactory
+      .connect(deployer)
+      .deploy(mockJbSplitsStore.address);
+
+    await jbSplitsPayer
+      .connect(deployer)
+      ['initialize(uint256,uint256,uint256,uint256,address,bool,string,bytes,bool,address)'](
+        DEFAULT_SPLITS_PROJECT_ID,
+        DEFAULT_SPLITS_DOMAIN,
+        DEFAULT_SPLITS_GROUP,
+        DEFAULT_PROJECT_ID,
+        DEFAULT_BENEFICIARY,
+        DEFAULT_PREFER_CLAIMED_TOKENS,
+        DEFAULT_MEMO,
+        DEFAULT_METADATA,
+        PREFER_ADD_TO_BALANCE,
+        owner.address,
+      );
 
     return {
       deployer,

--- a/test/jb_eth_erc20_splits_payer_deployer/add_to_balance.test.js
+++ b/test/jb_eth_erc20_splits_payer_deployer/add_to_balance.test.js
@@ -66,17 +66,37 @@ describe('JBETHERC20SplitsPayer with Proxy::addToBalanceOf(...)', function () {
     let mockJbTerminal = await deployMockContract(deployer, jbTerminal.abi);
     let mockToken = await smock.fake(ierc20.abi);
 
-    let jbSplitsPayerFactory = await ethers.getContractFactory(
-      'contracts/JBETHERC20SplitsPayer.sol:JBETHERC20SplitsPayer',
-    );
-
     await mockJbSplitsStore.mock.directory.returns(mockJbDirectory.address);
 
-    let jbSplitsPayer = await jbSplitsPayerFactory.deploy(
+    let jbSplitsPayerDeployerFactory = await ethers.getContractFactory(
+      'contracts/JBETHERC20SplitsPayerDeployer.sol:JBETHERC20SplitsPayerDeployer',
+    );
+
+    let jbSplitsPayerDeployer = await jbSplitsPayerDeployerFactory.deploy(
+      mockJbSplitsStore.address,
+    );
+
+    let jbSplitsPayerFactory = await ethers.getContractFactory('JBETHERC20SplitsPayer');
+
+    let jbSplitsPayer = jbSplitsPayerFactory.attach(
+      await jbSplitsPayerDeployer.callStatic.deploySplitsPayer(
+        DEFAULT_SPLITS_PROJECT_ID,
+        DEFAULT_SPLITS_DOMAIN,
+        DEFAULT_SPLITS_GROUP,
+        DEFAULT_PROJECT_ID,
+        DEFAULT_BENEFICIARY,
+        DEFAULT_PREFER_CLAIMED_TOKENS,
+        DEFAULT_MEMO,
+        DEFAULT_METADATA,
+        PREFER_ADD_TO_BALANCE,
+        owner.address,
+      ),
+    );
+
+    await jbSplitsPayerDeployer.deploySplitsPayer(
       DEFAULT_SPLITS_PROJECT_ID,
       DEFAULT_SPLITS_DOMAIN,
       DEFAULT_SPLITS_GROUP,
-      mockJbSplitsStore.address,
       DEFAULT_PROJECT_ID,
       DEFAULT_BENEFICIARY,
       DEFAULT_PREFER_CLAIMED_TOKENS,
@@ -101,6 +121,7 @@ describe('JBETHERC20SplitsPayer with Proxy::addToBalanceOf(...)', function () {
       mockJbSplitsStore,
       jbSplitsPayer,
       jbSplitsPayerFactory,
+      jbSplitsPayerDeployer,
     };
   }
 
@@ -726,15 +747,30 @@ describe('JBETHERC20SplitsPayer with Proxy::addToBalanceOf(...)', function () {
   });
 
   it(`Should send fund directly to the caller, if no allocator, project ID, beneficiary or default beneficiary is set,  and emit event`, async function () {
-    const { caller, jbSplitsPayerFactory, mockJbSplitsStore, owner } = await setup();
+    const { caller, jbSplitsPayerDeployer, jbSplitsPayerFactory, mockJbSplitsStore, owner } =
+      await setup();
 
     let splits = makeSplits();
 
-    let jbSplitsPayerWithoutDefaultBeneficiary = await jbSplitsPayerFactory.deploy(
+    let jbSplitsPayerWithoutDefaultBeneficiary = jbSplitsPayerFactory.attach(
+      await jbSplitsPayerDeployer.callStatic.deploySplitsPayer(
+        DEFAULT_SPLITS_PROJECT_ID,
+        DEFAULT_SPLITS_DOMAIN,
+        DEFAULT_SPLITS_GROUP,
+        DEFAULT_PROJECT_ID,
+        ethers.constants.AddressZero,
+        DEFAULT_PREFER_CLAIMED_TOKENS,
+        DEFAULT_MEMO,
+        DEFAULT_METADATA,
+        PREFER_ADD_TO_BALANCE,
+        owner.address,
+      ),
+    );
+
+    await jbSplitsPayerDeployer.deploySplitsPayer(
       DEFAULT_SPLITS_PROJECT_ID,
       DEFAULT_SPLITS_DOMAIN,
       DEFAULT_SPLITS_GROUP,
-      mockJbSplitsStore.address,
       DEFAULT_PROJECT_ID,
       ethers.constants.AddressZero,
       DEFAULT_PREFER_CLAIMED_TOKENS,
@@ -903,6 +939,7 @@ describe('JBETHERC20SplitsPayer with Proxy::addToBalanceOf(...)', function () {
       caller,
       owner,
       jbSplitsPayerFactory,
+      jbSplitsPayerDeployer,
       mockJbSplitsStore,
       mockJbTerminal,
       beneficiaryOne,
@@ -910,11 +947,25 @@ describe('JBETHERC20SplitsPayer with Proxy::addToBalanceOf(...)', function () {
       beneficiaryThree,
     } = await setup();
 
-    let jbSplitsPayer = await jbSplitsPayerFactory.deploy(
+    let jbSplitsPayer = jbSplitsPayerFactory.attach(
+      await jbSplitsPayerDeployer.callStatic.deploySplitsPayer(
+        DEFAULT_SPLITS_PROJECT_ID,
+        DEFAULT_SPLITS_DOMAIN,
+        DEFAULT_SPLITS_GROUP,
+        DEFAULT_PROJECT_ID,
+        beneficiaryThree.address,
+        DEFAULT_PREFER_CLAIMED_TOKENS,
+        DEFAULT_MEMO,
+        DEFAULT_METADATA,
+        PREFER_ADD_TO_BALANCE,
+        owner.address,
+      ),
+    );
+
+    await jbSplitsPayerDeployer.deploySplitsPayer(
       DEFAULT_SPLITS_PROJECT_ID,
       DEFAULT_SPLITS_DOMAIN,
       DEFAULT_SPLITS_GROUP,
-      mockJbSplitsStore.address,
       DEFAULT_PROJECT_ID,
       beneficiaryThree.address,
       DEFAULT_PREFER_CLAIMED_TOKENS,
@@ -976,6 +1027,7 @@ describe('JBETHERC20SplitsPayer with Proxy::addToBalanceOf(...)', function () {
       caller,
       owner,
       jbSplitsPayerFactory,
+      jbSplitsPayerDeployer,
       mockToken,
       mockJbSplitsStore,
       beneficiaryOne,
@@ -983,11 +1035,25 @@ describe('JBETHERC20SplitsPayer with Proxy::addToBalanceOf(...)', function () {
       beneficiaryThree,
     } = await setup();
 
-    let jbSplitsPayer = await jbSplitsPayerFactory.deploy(
+    let jbSplitsPayer = jbSplitsPayerFactory.attach(
+      await jbSplitsPayerDeployer.callStatic.deploySplitsPayer(
+        DEFAULT_SPLITS_PROJECT_ID,
+        DEFAULT_SPLITS_DOMAIN,
+        DEFAULT_SPLITS_GROUP,
+        DEFAULT_PROJECT_ID,
+        beneficiaryThree.address,
+        DEFAULT_PREFER_CLAIMED_TOKENS,
+        DEFAULT_MEMO,
+        DEFAULT_METADATA,
+        PREFER_ADD_TO_BALANCE,
+        owner.address,
+      ),
+    );
+
+    await jbSplitsPayerDeployer.deploySplitsPayer(
       DEFAULT_SPLITS_PROJECT_ID,
       DEFAULT_SPLITS_DOMAIN,
       DEFAULT_SPLITS_GROUP,
-      mockJbSplitsStore.address,
       DEFAULT_PROJECT_ID,
       beneficiaryThree.address,
       DEFAULT_PREFER_CLAIMED_TOKENS,
@@ -1053,6 +1119,7 @@ describe('JBETHERC20SplitsPayer with Proxy::addToBalanceOf(...)', function () {
       caller,
       owner,
       jbSplitsPayerFactory,
+      jbSplitsPayerDeployer,
       mockJbDirectory,
       mockJbSplitsStore,
       mockJbTerminal,
@@ -1061,11 +1128,25 @@ describe('JBETHERC20SplitsPayer with Proxy::addToBalanceOf(...)', function () {
       beneficiaryThree,
     } = await setup();
 
-    let jbSplitsPayer = await jbSplitsPayerFactory.deploy(
+    let jbSplitsPayer = jbSplitsPayerFactory.attach(
+      await jbSplitsPayerDeployer.callStatic.deploySplitsPayer(
+        DEFAULT_SPLITS_PROJECT_ID,
+        DEFAULT_SPLITS_DOMAIN,
+        DEFAULT_SPLITS_GROUP,
+        DEFAULT_PROJECT_ID,
+        ethers.constants.AddressZero,
+        DEFAULT_PREFER_CLAIMED_TOKENS,
+        DEFAULT_MEMO,
+        DEFAULT_METADATA,
+        PREFER_ADD_TO_BALANCE,
+        owner.address,
+      ),
+    );
+
+    await jbSplitsPayerDeployer.deploySplitsPayer(
       DEFAULT_SPLITS_PROJECT_ID,
       DEFAULT_SPLITS_DOMAIN,
       DEFAULT_SPLITS_GROUP,
-      mockJbSplitsStore.address,
       DEFAULT_PROJECT_ID,
       ethers.constants.AddressZero,
       DEFAULT_PREFER_CLAIMED_TOKENS,
@@ -1126,6 +1207,7 @@ describe('JBETHERC20SplitsPayer with Proxy::addToBalanceOf(...)', function () {
       caller,
       owner,
       jbSplitsPayerFactory,
+      jbSplitsPayerDeployer,
       mockJbSplitsStore,
       mockToken,
       beneficiaryOne,
@@ -1133,11 +1215,25 @@ describe('JBETHERC20SplitsPayer with Proxy::addToBalanceOf(...)', function () {
       beneficiaryThree,
     } = await setup();
 
-    let jbSplitsPayer = await jbSplitsPayerFactory.deploy(
+    let jbSplitsPayer = jbSplitsPayerFactory.attach(
+      await jbSplitsPayerDeployer.callStatic.deploySplitsPayer(
+        DEFAULT_SPLITS_PROJECT_ID,
+        DEFAULT_SPLITS_DOMAIN,
+        DEFAULT_SPLITS_GROUP,
+        DEFAULT_PROJECT_ID,
+        ethers.constants.AddressZero,
+        DEFAULT_PREFER_CLAIMED_TOKENS,
+        DEFAULT_MEMO,
+        DEFAULT_METADATA,
+        PREFER_ADD_TO_BALANCE,
+        owner.address,
+      ),
+    );
+
+    await jbSplitsPayerDeployer.deploySplitsPayer(
       DEFAULT_SPLITS_PROJECT_ID,
       DEFAULT_SPLITS_DOMAIN,
       DEFAULT_SPLITS_GROUP,
-      mockJbSplitsStore.address,
       DEFAULT_PROJECT_ID,
       ethers.constants.AddressZero,
       DEFAULT_PREFER_CLAIMED_TOKENS,

--- a/test/jb_eth_erc20_splits_payer_deployer/add_to_balance.test.js
+++ b/test/jb_eth_erc20_splits_payer_deployer/add_to_balance.test.js
@@ -1,0 +1,1218 @@
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { makeSplits } from '../helpers/utils.js';
+import { smock } from '@defi-wonderland/smock';
+
+import { deployMockContract } from '@ethereum-waffle/mock-contract';
+
+import errors from '../helpers/errors.json';
+import ierc20 from '../../artifacts/@openzeppelin/contracts/token/ERC20/ERC20.sol/ERC20.json';
+import jbAllocator from '../../artifacts/contracts/interfaces/IJBSplitAllocator.sol/IJBSplitAllocator.json';
+import jbDirectory from '../../artifacts/contracts/JBDirectory.sol/JBDirectory.json';
+import jbSplitsStore from '../../artifacts/contracts/JBSplitsStore.sol/JBSplitsStore.json';
+import jbTerminal from '../../artifacts/contracts/abstract/JBPayoutRedemptionPaymentTerminal.sol/JBPayoutRedemptionPaymentTerminal.json';
+
+describe('JBETHERC20SplitsPayer with Proxy::addToBalanceOf(...)', function () {
+  const DEFAULT_PROJECT_ID = 2;
+  const DEFAULT_SPLITS_PROJECT_ID = 3;
+  const DEFAULT_SPLITS_DOMAIN = 1;
+  const DEFAULT_SPLITS_GROUP = 1;
+  const DECIMALS = 18;
+  let DEFAULT_BENEFICIARY;
+  const DEFAULT_PREFER_CLAIMED_TOKENS = false;
+  const DEFAULT_MEMO = 'hello world';
+  const DEFAULT_METADATA = '0x42';
+
+  const PROJECT_ID = 69;
+  const AMOUNT = ethers.utils.parseEther('1.0');
+  const PREFER_ADD_TO_BALANCE = false;
+  const BENEFICIARY = ethers.Wallet.createRandom().address;
+  const PREFER_CLAIMED_TOKENS = true;
+  const MIN_RETURNED_TOKENS = 1;
+  const MEMO = 'hi world';
+  const METADATA = '0x69';
+
+  let ethToken;
+  let maxSplitsPercent;
+
+  this.beforeAll(async function () {
+    let jbTokensFactory = await ethers.getContractFactory('JBTokens');
+    let jbTokens = await jbTokensFactory.deploy();
+
+    ethToken = await jbTokens.ETH();
+
+    let jbConstantsFactory = await ethers.getContractFactory('JBConstants');
+    let jbConstants = await jbConstantsFactory.deploy();
+
+    maxSplitsPercent = await jbConstants.SPLITS_TOTAL_PERCENT();
+  });
+
+  async function setup() {
+    let [
+      deployer,
+      owner,
+      caller,
+      beneficiaryOne,
+      beneficiaryTwo,
+      beneficiaryThree,
+      defaultBeneficiarySigner,
+      ...addrs
+    ] = await ethers.getSigners();
+
+    DEFAULT_BENEFICIARY = defaultBeneficiarySigner.address;
+
+    let mockJbDirectory = await deployMockContract(deployer, jbDirectory.abi);
+    let mockJbSplitsStore = await deployMockContract(deployer, jbSplitsStore.abi);
+    let mockJbTerminal = await deployMockContract(deployer, jbTerminal.abi);
+    let mockToken = await smock.fake(ierc20.abi);
+
+    let jbSplitsPayerFactory = await ethers.getContractFactory(
+      'contracts/JBETHERC20SplitsPayer.sol:JBETHERC20SplitsPayer',
+    );
+
+    await mockJbSplitsStore.mock.directory.returns(mockJbDirectory.address);
+
+    let jbSplitsPayer = await jbSplitsPayerFactory.deploy(
+      DEFAULT_SPLITS_PROJECT_ID,
+      DEFAULT_SPLITS_DOMAIN,
+      DEFAULT_SPLITS_GROUP,
+      mockJbSplitsStore.address,
+      DEFAULT_PROJECT_ID,
+      DEFAULT_BENEFICIARY,
+      DEFAULT_PREFER_CLAIMED_TOKENS,
+      DEFAULT_MEMO,
+      DEFAULT_METADATA,
+      PREFER_ADD_TO_BALANCE,
+      owner.address,
+    );
+
+    return {
+      beneficiaryOne,
+      beneficiaryTwo,
+      beneficiaryThree,
+      defaultBeneficiarySigner,
+      deployer,
+      caller,
+      owner,
+      addrs,
+      mockToken,
+      mockJbDirectory,
+      mockJbTerminal,
+      mockJbSplitsStore,
+      jbSplitsPayer,
+      jbSplitsPayerFactory,
+    };
+  }
+
+  it(`Should send ETH towards allocator if set in split and emit event`, async function () {
+    const { deployer, caller, jbSplitsPayer, mockJbSplitsStore } = await setup();
+
+    let mockJbAllocator = await deployMockContract(deployer, jbAllocator.abi);
+
+    let splits = makeSplits({ projectId: PROJECT_ID, allocator: mockJbAllocator.address });
+
+    await Promise.all(
+      splits.map(async (split) => {
+        await mockJbAllocator.mock.allocate
+          .withArgs({
+            token: ethToken,
+            amount: AMOUNT.mul(split.percent).div(maxSplitsPercent),
+            decimals: 18,
+            projectId: DEFAULT_PROJECT_ID,
+            group: 0,
+            split: split,
+          })
+          .returns();
+      }),
+    );
+
+    // Payment routing
+    await mockJbSplitsStore.mock.splitsOf
+      .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
+      .returns(splits);
+
+    let tx = await jbSplitsPayer
+      .connect(caller)
+      .addToBalanceOf(PROJECT_ID, ethToken, AMOUNT, DECIMALS, MEMO, METADATA, {
+        value: AMOUNT,
+      });
+
+    await expect(tx).to.changeEtherBalance(mockJbAllocator, AMOUNT);
+
+    await Promise.all(
+      splits.map(async (split) => {
+        await expect(tx)
+          .to.emit(jbSplitsPayer, 'DistributeToSplit')
+          .withArgs(
+            [
+              split.preferClaimed,
+              split.preferAddToBalance,
+              split.percent,
+              split.projectId,
+              split.beneficiary,
+              split.lockedUntil,
+              split.allocator,
+            ],
+            AMOUNT.mul(split.percent).div(maxSplitsPercent),
+            DEFAULT_BENEFICIARY,
+            caller.address,
+          );
+      }),
+    );
+
+    await expect(tx)
+      .to.emit(jbSplitsPayer, 'DistributeToSplitGroup')
+      .withArgs(
+        DEFAULT_SPLITS_PROJECT_ID,
+        DEFAULT_SPLITS_DOMAIN,
+        DEFAULT_SPLITS_GROUP,
+        caller.address,
+      );
+
+    await expect(tx).to.emit(jbSplitsPayer, 'AddToBalance').withArgs(
+      PROJECT_ID,
+      DEFAULT_BENEFICIARY,
+      ethToken,
+      AMOUNT,
+      DECIMALS,
+      0, //leftover
+      MEMO,
+      METADATA,
+      caller.address,
+    );
+  });
+
+  it(`Should send ERC20 with 9-decimals towards allocator if set in split and emit event`, async function () {
+    const { caller, deployer, jbSplitsPayer, mockToken, mockJbSplitsStore } = await setup();
+    const DECIMALS = 9;
+
+    let mockJbAllocator = await deployMockContract(deployer, jbAllocator.abi);
+
+    let splits = makeSplits({ projectId: PROJECT_ID, allocator: mockJbAllocator.address });
+
+    await Promise.all(
+      splits.map(async (split) => {
+        mockToken.allowance
+          .whenCalledWith(jbSplitsPayer.address, mockJbAllocator.address)
+          .returns(0);
+
+        mockToken.approve
+          .whenCalledWith(mockJbAllocator.address, AMOUNT.mul(split.percent).div(maxSplitsPercent))
+          .returns(true);
+
+        await mockJbAllocator.mock.allocate
+          .withArgs({
+            token: mockToken.address,
+            amount: AMOUNT.mul(split.percent).div(maxSplitsPercent),
+            decimals: DECIMALS,
+            projectId: DEFAULT_PROJECT_ID,
+            group: 0,
+            split: split,
+          })
+          .returns();
+      }),
+    );
+
+    await mockJbSplitsStore.mock.splitsOf
+      .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
+      .returns(splits);
+
+    mockToken.balanceOf.returnsAtCall(0, 0);
+
+    mockToken.transferFrom
+      .whenCalledWith(caller.address, jbSplitsPayer.address, AMOUNT)
+      .returns(true);
+
+    mockToken.balanceOf.returnsAtCall(1, AMOUNT);
+
+    let tx = jbSplitsPayer
+      .connect(caller)
+      .addToBalanceOf(PROJECT_ID, mockToken.address, AMOUNT, DECIMALS, MEMO, METADATA);
+
+    await expect(tx).to.emit(jbSplitsPayer, 'AddToBalance').withArgs(
+      PROJECT_ID,
+      DEFAULT_BENEFICIARY,
+      mockToken.address,
+      AMOUNT,
+      DECIMALS,
+      0, //leftover
+      MEMO,
+      METADATA,
+      caller.address,
+    );
+
+    await Promise.all(
+      splits.map(async (split) => {
+        await expect(tx)
+          .to.emit(jbSplitsPayer, 'DistributeToSplit')
+          .withArgs(
+            [
+              split.preferClaimed,
+              split.preferAddToBalance,
+              split.percent,
+              split.projectId,
+              split.beneficiary,
+              split.lockedUntil,
+              split.allocator,
+            ],
+            AMOUNT.mul(split.percent).div(maxSplitsPercent),
+            DEFAULT_BENEFICIARY,
+            caller.address,
+          );
+      }),
+    );
+
+    await expect(tx)
+      .to.emit(jbSplitsPayer, 'DistributeToSplitGroup')
+      .withArgs(
+        DEFAULT_SPLITS_PROJECT_ID,
+        DEFAULT_SPLITS_DOMAIN,
+        DEFAULT_SPLITS_GROUP,
+        caller.address,
+      );
+  });
+
+  it(`Should send ERC20 with 9-decimals towards allocator supporting fee on transfer token`, async function () {
+    const { caller, deployer, jbSplitsPayer, mockToken, mockJbSplitsStore } = await setup();
+    const DECIMALS = 9;
+    const NET_AMOUNT = AMOUNT.sub(100);
+
+    let mockJbAllocator = await deployMockContract(deployer, jbAllocator.abi);
+
+    let splits = makeSplits({ projectId: PROJECT_ID, allocator: mockJbAllocator.address });
+
+    await Promise.all(
+      splits.map(async (split) => {
+        mockToken.allowance
+          .whenCalledWith(jbSplitsPayer.address, mockJbAllocator.address)
+          .returns(0);
+
+        mockToken.approve
+          .whenCalledWith(
+            mockJbAllocator.address,
+            NET_AMOUNT.mul(split.percent).div(maxSplitsPercent),
+          )
+          .returns(true);
+
+        await mockJbAllocator.mock.allocate
+          .withArgs({
+            token: mockToken.address,
+            amount: NET_AMOUNT.mul(split.percent).div(maxSplitsPercent),
+            decimals: DECIMALS,
+            projectId: DEFAULT_PROJECT_ID,
+            group: 0,
+            split: split,
+          })
+          .returns();
+      }),
+    );
+
+    await mockJbSplitsStore.mock.splitsOf
+      .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
+      .returns(splits);
+
+    mockToken.balanceOf.returnsAtCall(0, 0);
+
+    mockToken.transferFrom
+      .whenCalledWith(caller.address, jbSplitsPayer.address, AMOUNT)
+      .returns(true);
+
+    mockToken.balanceOf.returnsAtCall(1, NET_AMOUNT);
+
+    let tx = jbSplitsPayer
+      .connect(caller)
+      .addToBalanceOf(PROJECT_ID, mockToken.address, AMOUNT, DECIMALS, MEMO, METADATA);
+
+    await expect(tx).to.emit(jbSplitsPayer, 'AddToBalance').withArgs(
+      PROJECT_ID,
+      DEFAULT_BENEFICIARY,
+      mockToken.address,
+      NET_AMOUNT,
+      DECIMALS,
+      0, //leftover
+      MEMO,
+      METADATA,
+      caller.address,
+    );
+
+    await Promise.all(
+      splits.map(async (split) => {
+        await expect(tx)
+          .to.emit(jbSplitsPayer, 'DistributeToSplit')
+          .withArgs(
+            [
+              split.preferClaimed,
+              split.preferAddToBalance,
+              split.percent,
+              split.projectId,
+              split.beneficiary,
+              split.lockedUntil,
+              split.allocator,
+            ],
+            NET_AMOUNT.mul(split.percent).div(maxSplitsPercent),
+            DEFAULT_BENEFICIARY,
+            caller.address,
+          );
+      }),
+    );
+
+    await expect(tx)
+      .to.emit(jbSplitsPayer, 'DistributeToSplitGroup')
+      .withArgs(
+        DEFAULT_SPLITS_PROJECT_ID,
+        DEFAULT_SPLITS_DOMAIN,
+        DEFAULT_SPLITS_GROUP,
+        caller.address,
+      );
+  });
+
+  it(`Should send fund towards project terminal if project ID is set in split and add to balance if it is prefered and emit event`, async function () {
+    const { caller, jbSplitsPayer, mockJbSplitsStore, mockJbDirectory, mockJbTerminal } =
+      await setup();
+
+    let splits = makeSplits({ projectId: PROJECT_ID, preferAddToBalance: true });
+
+    await mockJbDirectory.mock.primaryTerminalOf
+      .withArgs(PROJECT_ID, ethToken)
+      .returns(mockJbTerminal.address);
+
+    await mockJbTerminal.mock.decimalsForToken.withArgs(ethToken).returns(18);
+
+    await Promise.all(
+      splits.map(async (split) => {
+        await mockJbTerminal.mock.addToBalanceOf
+          .withArgs(
+            split.projectId,
+            AMOUNT.mul(split.percent).div(maxSplitsPercent),
+            ethToken,
+            DEFAULT_MEMO,
+            DEFAULT_METADATA,
+          )
+          .returns();
+      }),
+    );
+
+    await mockJbSplitsStore.mock.splitsOf
+      .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
+      .returns(splits);
+
+    let tx = await jbSplitsPayer
+      .connect(caller)
+      .addToBalanceOf(PROJECT_ID, ethToken, AMOUNT, DECIMALS, MEMO, METADATA, {
+        value: AMOUNT,
+      });
+
+    await expect(tx).to.changeEtherBalance(mockJbTerminal, AMOUNT);
+
+    await expect(tx).to.emit(jbSplitsPayer, 'AddToBalance').withArgs(
+      PROJECT_ID,
+      DEFAULT_BENEFICIARY,
+      ethToken,
+      AMOUNT,
+      DECIMALS,
+      0, //leftover
+      MEMO,
+      METADATA,
+      caller.address,
+    );
+
+    await Promise.all(
+      splits.map(async (split) => {
+        await expect(tx)
+          .to.emit(jbSplitsPayer, 'DistributeToSplit')
+          .withArgs(
+            [
+              split.preferClaimed,
+              split.preferAddToBalance,
+              split.percent,
+              split.projectId,
+              split.beneficiary,
+              split.lockedUntil,
+              split.allocator,
+            ],
+            AMOUNT.mul(split.percent).div(maxSplitsPercent),
+            DEFAULT_BENEFICIARY,
+            caller.address,
+          );
+      }),
+    );
+
+    await expect(tx)
+      .to.emit(jbSplitsPayer, 'DistributeToSplitGroup')
+      .withArgs(
+        DEFAULT_SPLITS_PROJECT_ID,
+        DEFAULT_SPLITS_DOMAIN,
+        DEFAULT_SPLITS_GROUP,
+        caller.address,
+      );
+  });
+
+  it(`Should send fund towards project terminal if project ID is set in split, using pay with beneficiaries set in splits and emit event`, async function () {
+    const {
+      caller,
+      beneficiaryOne,
+      beneficiaryTwo,
+      jbSplitsPayer,
+      mockJbSplitsStore,
+      mockJbDirectory,
+      mockJbTerminal,
+    } = await setup();
+    let splits = makeSplits({
+      count: 2,
+      projectId: PROJECT_ID,
+      beneficiary: [beneficiaryOne.address, beneficiaryTwo.address],
+    });
+
+    await mockJbDirectory.mock.primaryTerminalOf
+      .withArgs(PROJECT_ID, ethToken)
+      .returns(mockJbTerminal.address);
+
+    await mockJbTerminal.mock.decimalsForToken.withArgs(ethToken).returns(18);
+
+    await Promise.all(
+      splits.map(async (split) => {
+        await mockJbTerminal.mock.pay
+          .withArgs(
+            split.projectId,
+            AMOUNT.mul(split.percent).div(maxSplitsPercent),
+            ethToken,
+            split.beneficiary,
+            0 /*hardcoded*/,
+            split.preferClaimed,
+            DEFAULT_MEMO,
+            DEFAULT_METADATA,
+          )
+          .returns(0); // Not used
+      }),
+    );
+
+    await mockJbSplitsStore.mock.splitsOf
+      .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
+      .returns(splits);
+
+    let tx = await jbSplitsPayer
+      .connect(caller)
+      .addToBalanceOf(PROJECT_ID, ethToken, AMOUNT, DECIMALS, MEMO, METADATA, {
+        value: AMOUNT,
+      });
+
+    await expect(tx).to.changeEtherBalance(mockJbTerminal, AMOUNT);
+
+    await expect(tx).to.emit(jbSplitsPayer, 'AddToBalance').withArgs(
+      PROJECT_ID,
+      DEFAULT_BENEFICIARY,
+      ethToken,
+      AMOUNT,
+      DECIMALS,
+      0, //leftover
+      MEMO,
+      METADATA,
+      caller.address,
+    );
+
+    await Promise.all(
+      splits.map(async (split) => {
+        await expect(tx)
+          .to.emit(jbSplitsPayer, 'DistributeToSplit')
+          .withArgs(
+            [
+              split.preferClaimed,
+              split.preferAddToBalance,
+              split.percent,
+              split.projectId,
+              split.beneficiary,
+              split.lockedUntil,
+              split.allocator,
+            ],
+            AMOUNT.mul(split.percent).div(maxSplitsPercent),
+            DEFAULT_BENEFICIARY,
+            caller.address,
+          );
+      }),
+    );
+
+    await expect(tx)
+      .to.emit(jbSplitsPayer, 'DistributeToSplitGroup')
+      .withArgs(
+        DEFAULT_SPLITS_PROJECT_ID,
+        DEFAULT_SPLITS_DOMAIN,
+        DEFAULT_SPLITS_GROUP,
+        caller.address,
+      );
+  });
+
+  it(`Should send fund towards project terminal if project ID is set in split, using pay with the default beneficiary if none is set in splits and emit event`, async function () {
+    const { caller, jbSplitsPayer, mockJbSplitsStore, mockJbDirectory, mockJbTerminal } =
+      await setup();
+
+    let splits = makeSplits({ projectId: PROJECT_ID });
+
+    await mockJbDirectory.mock.primaryTerminalOf
+      .withArgs(PROJECT_ID, ethToken)
+      .returns(mockJbTerminal.address);
+
+    await mockJbTerminal.mock.decimalsForToken.withArgs(ethToken).returns(18);
+
+    await Promise.all(
+      splits.map(async (split) => {
+        await mockJbTerminal.mock.pay
+          .withArgs(
+            split.projectId,
+            AMOUNT.mul(split.percent).div(maxSplitsPercent),
+            ethToken,
+            DEFAULT_BENEFICIARY,
+            0 /*hardcoded*/,
+            split.preferClaimed,
+            DEFAULT_MEMO,
+            DEFAULT_METADATA,
+          )
+          .returns(0); // Not used
+      }),
+    );
+
+    await mockJbSplitsStore.mock.splitsOf
+      .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
+      .returns(splits);
+
+    let tx = await jbSplitsPayer
+      .connect(caller)
+      .addToBalanceOf(PROJECT_ID, ethToken, AMOUNT, DECIMALS, MEMO, METADATA, {
+        value: AMOUNT,
+      });
+
+    await expect(tx).to.changeEtherBalance(mockJbTerminal, AMOUNT);
+
+    await expect(tx).to.emit(jbSplitsPayer, 'AddToBalance').withArgs(
+      PROJECT_ID,
+      DEFAULT_BENEFICIARY,
+      ethToken,
+      AMOUNT,
+      DECIMALS,
+      0, //leftover
+      MEMO,
+      METADATA,
+      caller.address,
+    );
+
+    await Promise.all(
+      splits.map(async (split) => {
+        await expect(tx)
+          .to.emit(jbSplitsPayer, 'DistributeToSplit')
+          .withArgs(
+            [
+              split.preferClaimed,
+              split.preferAddToBalance,
+              split.percent,
+              split.projectId,
+              split.beneficiary,
+              split.lockedUntil,
+              split.allocator,
+            ],
+            AMOUNT.mul(split.percent).div(maxSplitsPercent),
+            DEFAULT_BENEFICIARY,
+            caller.address,
+          );
+      }),
+    );
+
+    await expect(tx)
+      .to.emit(jbSplitsPayer, 'DistributeToSplitGroup')
+      .withArgs(
+        DEFAULT_SPLITS_PROJECT_ID,
+        DEFAULT_SPLITS_DOMAIN,
+        DEFAULT_SPLITS_GROUP,
+        caller.address,
+      );
+  });
+
+  it(`Should send fund directly to a beneficiary set in split, if no allocator or project ID is set in splits and emit event`, async function () {
+    const { caller, beneficiaryOne, beneficiaryTwo, jbSplitsPayer, mockJbSplitsStore } =
+      await setup();
+
+    let splits = makeSplits({
+      count: 2,
+      beneficiary: [beneficiaryOne.address, beneficiaryTwo.address],
+    });
+
+    await mockJbSplitsStore.mock.splitsOf
+      .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
+      .returns(splits);
+
+    let tx = await jbSplitsPayer
+      .connect(caller)
+      .addToBalanceOf(PROJECT_ID, ethToken, AMOUNT, DECIMALS, MEMO, METADATA, {
+        value: AMOUNT,
+      });
+    await expect(tx).to.changeEtherBalance(
+      beneficiaryOne,
+      AMOUNT.mul(splits[0].percent).div(maxSplitsPercent),
+    );
+    await expect(tx).to.changeEtherBalance(
+      beneficiaryTwo,
+      AMOUNT.mul(splits[0].percent).div(maxSplitsPercent),
+    );
+
+    await expect(tx).to.emit(jbSplitsPayer, 'AddToBalance').withArgs(
+      PROJECT_ID,
+      DEFAULT_BENEFICIARY,
+      ethToken,
+      AMOUNT,
+      DECIMALS,
+      0, //leftover
+      MEMO,
+      METADATA,
+      caller.address,
+    );
+
+    await Promise.all(
+      splits.map(async (split) => {
+        await expect(tx)
+          .to.emit(jbSplitsPayer, 'DistributeToSplit')
+          .withArgs(
+            [
+              split.preferClaimed,
+              split.preferAddToBalance,
+              split.percent,
+              split.projectId,
+              split.beneficiary,
+              split.lockedUntil,
+              split.allocator,
+            ],
+            AMOUNT.mul(split.percent).div(maxSplitsPercent),
+            DEFAULT_BENEFICIARY,
+            caller.address,
+          );
+      }),
+    );
+
+    await expect(tx)
+      .to.emit(jbSplitsPayer, 'DistributeToSplitGroup')
+      .withArgs(
+        DEFAULT_SPLITS_PROJECT_ID,
+        DEFAULT_SPLITS_DOMAIN,
+        DEFAULT_SPLITS_GROUP,
+        caller.address,
+      );
+  });
+
+  it(`Should send fund directly to the default beneficiary, if no allocator, project ID or beneficiary is set,  and emit event`, async function () {
+    const { caller, jbSplitsPayer, mockJbSplitsStore, defaultBeneficiarySigner } = await setup();
+
+    let splits = makeSplits();
+
+    await mockJbSplitsStore.mock.splitsOf
+      .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
+      .returns(splits);
+
+    let tx = await jbSplitsPayer
+      .connect(caller)
+      .addToBalanceOf(PROJECT_ID, ethToken, AMOUNT, DECIMALS, MEMO, METADATA, {
+        value: AMOUNT,
+      });
+
+    await expect(tx).to.changeEtherBalance(defaultBeneficiarySigner, AMOUNT); // Send then receive the amount (gas is not taken into account)
+
+    await expect(tx).to.emit(jbSplitsPayer, 'AddToBalance').withArgs(
+      PROJECT_ID,
+      DEFAULT_BENEFICIARY,
+      ethToken,
+      AMOUNT,
+      DECIMALS,
+      0, //leftover
+      MEMO,
+      METADATA,
+      caller.address,
+    );
+  });
+
+  it(`Should send fund directly to the caller, if no allocator, project ID, beneficiary or default beneficiary is set,  and emit event`, async function () {
+    const { caller, jbSplitsPayerFactory, mockJbSplitsStore, owner } = await setup();
+
+    let splits = makeSplits();
+
+    let jbSplitsPayerWithoutDefaultBeneficiary = await jbSplitsPayerFactory.deploy(
+      DEFAULT_SPLITS_PROJECT_ID,
+      DEFAULT_SPLITS_DOMAIN,
+      DEFAULT_SPLITS_GROUP,
+      mockJbSplitsStore.address,
+      DEFAULT_PROJECT_ID,
+      ethers.constants.AddressZero,
+      DEFAULT_PREFER_CLAIMED_TOKENS,
+      DEFAULT_MEMO,
+      DEFAULT_METADATA,
+      PREFER_ADD_TO_BALANCE,
+      owner.address,
+    );
+
+    await mockJbSplitsStore.mock.splitsOf
+      .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
+      .returns(splits);
+
+    let tx = await jbSplitsPayerWithoutDefaultBeneficiary
+      .connect(caller)
+      .addToBalanceOf(PROJECT_ID, ethToken, AMOUNT, DECIMALS, MEMO, METADATA, {
+        value: AMOUNT,
+      });
+
+    await expect(tx).to.changeEtherBalance(caller, 0); // Send then receive the amount (gas is not taken into account)
+
+    await expect(tx).to.emit(jbSplitsPayerWithoutDefaultBeneficiary, 'AddToBalance').withArgs(
+      PROJECT_ID,
+      caller.address,
+      ethToken,
+      AMOUNT,
+      DECIMALS,
+      0, //leftover
+      MEMO,
+      METADATA,
+      caller.address,
+    );
+  });
+
+  it(`Should send eth leftover to project id if set and emit event`, async function () {
+    const {
+      caller,
+      jbSplitsPayer,
+      mockJbDirectory,
+      mockJbSplitsStore,
+      mockJbTerminal,
+      beneficiaryOne,
+      beneficiaryTwo,
+      beneficiaryThree,
+    } = await setup();
+
+    // 50% to beneficiaries
+    let splits = makeSplits({
+      count: 2,
+      beneficiary: [beneficiaryOne.address, beneficiaryTwo.address],
+      percent: maxSplitsPercent.div('4'),
+    });
+
+    await mockJbSplitsStore.mock.splitsOf
+      .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
+      .returns(splits);
+
+    await mockJbTerminal.mock.decimalsForToken.withArgs(ethToken).returns(18);
+
+    await mockJbDirectory.mock.primaryTerminalOf
+      .withArgs(PROJECT_ID, ethToken)
+      .returns(mockJbTerminal.address);
+
+    await mockJbTerminal.mock.addToBalanceOf
+      .withArgs(PROJECT_ID, AMOUNT.div('2'), ethToken, MEMO, METADATA)
+      .returns();
+
+    let tx = await jbSplitsPayer
+      .connect(caller)
+      .addToBalanceOf(PROJECT_ID, ethToken, AMOUNT, DECIMALS, MEMO, METADATA, {
+        value: AMOUNT,
+      });
+
+    await expect(tx).to.changeEtherBalance(mockJbTerminal, AMOUNT.div('2'));
+
+    await expect(tx).to.emit(jbSplitsPayer, 'AddToBalance').withArgs(
+      PROJECT_ID,
+      DEFAULT_BENEFICIARY,
+      ethToken,
+      AMOUNT,
+      DECIMALS,
+      AMOUNT.div('2'), //leftover
+      MEMO,
+      METADATA,
+      caller.address,
+    );
+  });
+
+  it(`Should send erc20 leftover to project id if set and emit event`, async function () {
+    const {
+      caller,
+      jbSplitsPayer,
+      mockJbDirectory,
+      mockJbSplitsStore,
+      mockJbTerminal,
+      mockToken,
+      beneficiaryOne,
+      beneficiaryTwo,
+      beneficiaryThree,
+    } = await setup();
+    // 50% to beneficiaries
+    let splits = makeSplits({
+      count: 2,
+      beneficiary: [beneficiaryOne.address, beneficiaryTwo.address],
+      percent: maxSplitsPercent.div('4'),
+    });
+
+    mockToken.balanceOf.returnsAtCall(0, 0);
+
+    mockToken.transferFrom
+      .whenCalledWith(caller.address, jbSplitsPayer.address, AMOUNT)
+      .returns(true);
+
+    mockToken.balanceOf.returnsAtCall(1, AMOUNT);
+
+    await mockJbSplitsStore.mock.splitsOf
+      .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
+      .returns(splits);
+
+    // Transfer from splitsPayer to splits beneficiaries
+    await Promise.all(
+      splits.map(async (split) => {
+        mockToken.transfer
+          .whenCalledWith(split.beneficiary, AMOUNT.mul(split.percent).div(maxSplitsPercent))
+          .returns(true);
+      }),
+    );
+
+    // leftover: terminal of project ID
+    await mockJbDirectory.mock.primaryTerminalOf
+      .withArgs(PROJECT_ID, mockToken.address)
+      .returns(mockJbTerminal.address);
+
+    await mockJbTerminal.mock.decimalsForToken.withArgs(mockToken.address).returns(DECIMALS);
+
+    // Approve transfer to the default project ID terminal
+    mockToken.allowance.whenCalledWith(jbSplitsPayer.address, mockJbTerminal.address).returns(0);
+    mockToken.approve.whenCalledWith(mockJbTerminal.address, AMOUNT.div('2')).returns(true);
+
+    // Pay the leftover with the default beneficiary
+    await mockJbTerminal.mock.addToBalanceOf
+      .withArgs(PROJECT_ID, AMOUNT.div('2'), mockToken.address, MEMO, METADATA)
+      .returns();
+
+    await expect(
+      jbSplitsPayer
+        .connect(caller)
+        .addToBalanceOf(PROJECT_ID, mockToken.address, AMOUNT, DECIMALS, MEMO, METADATA),
+    )
+      .to.emit(jbSplitsPayer, 'AddToBalance')
+      .withArgs(
+        PROJECT_ID,
+        DEFAULT_BENEFICIARY,
+        mockToken.address,
+        AMOUNT,
+        DECIMALS,
+        AMOUNT.div('2'), //leftover
+        MEMO,
+        METADATA,
+        caller.address,
+      );
+  });
+
+  it(`Should send eth leftover to default beneficiary if no project id set and emit event`, async function () {
+    const {
+      caller,
+      owner,
+      jbSplitsPayerFactory,
+      mockJbSplitsStore,
+      mockJbTerminal,
+      beneficiaryOne,
+      beneficiaryTwo,
+      beneficiaryThree,
+    } = await setup();
+
+    let jbSplitsPayer = await jbSplitsPayerFactory.deploy(
+      DEFAULT_SPLITS_PROJECT_ID,
+      DEFAULT_SPLITS_DOMAIN,
+      DEFAULT_SPLITS_GROUP,
+      mockJbSplitsStore.address,
+      DEFAULT_PROJECT_ID,
+      beneficiaryThree.address,
+      DEFAULT_PREFER_CLAIMED_TOKENS,
+      DEFAULT_MEMO,
+      DEFAULT_METADATA,
+      PREFER_ADD_TO_BALANCE,
+      owner.address,
+    );
+
+    // 50% to beneficiaries
+    let splits = makeSplits({
+      count: 2,
+      beneficiary: [beneficiaryOne.address, beneficiaryTwo.address],
+      percent: maxSplitsPercent.div('4'),
+    });
+
+    await mockJbSplitsStore.mock.splitsOf
+      .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
+      .returns(splits);
+
+    await mockJbTerminal.mock.decimals.returns(18);
+
+    await mockJbTerminal.mock.pay
+      .withArgs(
+        0,
+        AMOUNT.div('2'),
+        ethToken,
+        beneficiaryThree.address,
+        MIN_RETURNED_TOKENS,
+        PREFER_CLAIMED_TOKENS,
+        MEMO,
+        METADATA,
+      )
+      .returns(0); // Not used
+
+    let tx = await jbSplitsPayer
+      .connect(caller)
+      .addToBalanceOf(0, ethToken, AMOUNT, DECIMALS, MEMO, METADATA, {
+        value: AMOUNT,
+      });
+
+    await expect(tx).to.changeEtherBalance(beneficiaryThree, AMOUNT.div('2'));
+
+    await expect(tx).to.emit(jbSplitsPayer, 'AddToBalance').withArgs(
+      0, //PROJECT_ID
+      beneficiaryThree.address,
+      ethToken,
+      AMOUNT,
+      DECIMALS,
+      AMOUNT.div('2'), //leftover
+      MEMO,
+      METADATA,
+      caller.address,
+    );
+  });
+
+  it(`Should send erc20 leftover to default beneficiary if no project id set and emit event`, async function () {
+    const {
+      caller,
+      owner,
+      jbSplitsPayerFactory,
+      mockToken,
+      mockJbSplitsStore,
+      beneficiaryOne,
+      beneficiaryTwo,
+      beneficiaryThree,
+    } = await setup();
+
+    let jbSplitsPayer = await jbSplitsPayerFactory.deploy(
+      DEFAULT_SPLITS_PROJECT_ID,
+      DEFAULT_SPLITS_DOMAIN,
+      DEFAULT_SPLITS_GROUP,
+      mockJbSplitsStore.address,
+      DEFAULT_PROJECT_ID,
+      beneficiaryThree.address,
+      DEFAULT_PREFER_CLAIMED_TOKENS,
+      DEFAULT_MEMO,
+      DEFAULT_METADATA,
+      PREFER_ADD_TO_BALANCE,
+      owner.address,
+    );
+
+    // 50% to beneficiaries
+    let splits = makeSplits({
+      count: 2,
+      beneficiary: [beneficiaryOne.address, beneficiaryTwo.address],
+      percent: maxSplitsPercent.div('4'),
+    });
+
+    // Transfer to splitsPayer
+    mockToken.balanceOf.returnsAtCall(0, 0);
+
+    mockToken.transferFrom
+      .whenCalledWith(caller.address, jbSplitsPayer.address, AMOUNT)
+      .returns(true);
+
+    mockToken.balanceOf.returnsAtCall(1, AMOUNT);
+
+    await mockJbSplitsStore.mock.splitsOf
+      .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
+      .returns(splits);
+
+    // Transfer from splitsPayer to splits beneficiaries
+    await Promise.all(
+      splits.map(async (split) => {
+        mockToken.transfer
+          .whenCalledWith(split.beneficiary, AMOUNT.mul(split.percent).div(maxSplitsPercent))
+          .returns(true);
+      }),
+    );
+
+    // Transfer from splitsPayer to default beneficiary
+    mockToken.transfer.whenCalledWith(beneficiaryThree.address, AMOUNT.div('2')).returns(true);
+
+    await expect(
+      jbSplitsPayer
+        .connect(caller)
+        .addToBalanceOf(0, mockToken.address, AMOUNT, DECIMALS, MEMO, METADATA),
+    )
+      .to.emit(jbSplitsPayer, 'AddToBalance')
+      .withArgs(
+        0, //PROJECT_ID,
+        beneficiaryThree.address,
+        mockToken.address,
+        AMOUNT,
+        DECIMALS,
+        AMOUNT.div('2'), //leftover
+        MEMO,
+        METADATA,
+        caller.address,
+      );
+  });
+
+  it(`Should send eth leftover to the caller if no project id nor default beneficiary is set and emit event`, async function () {
+    const {
+      caller,
+      owner,
+      jbSplitsPayerFactory,
+      mockJbDirectory,
+      mockJbSplitsStore,
+      mockJbTerminal,
+      beneficiaryOne,
+      beneficiaryTwo,
+      beneficiaryThree,
+    } = await setup();
+
+    let jbSplitsPayer = await jbSplitsPayerFactory.deploy(
+      DEFAULT_SPLITS_PROJECT_ID,
+      DEFAULT_SPLITS_DOMAIN,
+      DEFAULT_SPLITS_GROUP,
+      mockJbSplitsStore.address,
+      DEFAULT_PROJECT_ID,
+      ethers.constants.AddressZero,
+      DEFAULT_PREFER_CLAIMED_TOKENS,
+      DEFAULT_MEMO,
+      DEFAULT_METADATA,
+      PREFER_ADD_TO_BALANCE,
+      owner.address,
+    );
+
+    // 50% to beneficiaries
+    let splits = makeSplits({
+      count: 2,
+      beneficiary: [beneficiaryOne.address, beneficiaryTwo.address],
+      percent: maxSplitsPercent.div('4'),
+    });
+
+    await mockJbSplitsStore.mock.splitsOf
+      .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
+      .returns(splits);
+
+    await mockJbTerminal.mock.decimals.returns(18);
+
+    await mockJbTerminal.mock.pay
+      .withArgs(
+        0,
+        AMOUNT.div('2'),
+        ethToken,
+        ethers.constants.AddressZero,
+        MIN_RETURNED_TOKENS,
+        PREFER_CLAIMED_TOKENS,
+        MEMO,
+        METADATA,
+      )
+      .returns(0); // Not used
+
+    let tx = await jbSplitsPayer
+      .connect(caller)
+      .addToBalanceOf(0, ethToken, AMOUNT, DECIMALS, MEMO, METADATA, {
+        value: AMOUNT,
+      });
+    await expect(tx).to.changeEtherBalance(caller, AMOUNT.div('-2')); // Only 50% are dsitributed
+
+    await expect(tx).to.emit(jbSplitsPayer, 'AddToBalance').withArgs(
+      0,
+      caller.address,
+      ethToken,
+      AMOUNT,
+      DECIMALS,
+      AMOUNT.div('2'), //leftover
+      MEMO,
+      METADATA,
+      caller.address,
+    );
+  });
+
+  it(`Should send erc20 leftover to the caller if no project id nor beneficiary is set and emit event`, async function () {
+    const {
+      caller,
+      owner,
+      jbSplitsPayerFactory,
+      mockJbSplitsStore,
+      mockToken,
+      beneficiaryOne,
+      beneficiaryTwo,
+      beneficiaryThree,
+    } = await setup();
+
+    let jbSplitsPayer = await jbSplitsPayerFactory.deploy(
+      DEFAULT_SPLITS_PROJECT_ID,
+      DEFAULT_SPLITS_DOMAIN,
+      DEFAULT_SPLITS_GROUP,
+      mockJbSplitsStore.address,
+      DEFAULT_PROJECT_ID,
+      ethers.constants.AddressZero,
+      DEFAULT_PREFER_CLAIMED_TOKENS,
+      DEFAULT_MEMO,
+      DEFAULT_METADATA,
+      PREFER_ADD_TO_BALANCE,
+      owner.address,
+    );
+
+    // 50% to beneficiaries
+    let splits = makeSplits({
+      count: 2,
+      beneficiary: [beneficiaryOne.address, beneficiaryTwo.address],
+      percent: maxSplitsPercent.div('4'),
+    });
+
+    // Transfer to splitsPayer
+    mockToken.balanceOf.returnsAtCall(0, 0);
+
+    mockToken.transferFrom
+      .whenCalledWith(caller.address, jbSplitsPayer.address, AMOUNT)
+      .returns(true);
+
+    mockToken.balanceOf.returnsAtCall(1, AMOUNT);
+
+    await mockJbSplitsStore.mock.splitsOf
+      .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
+      .returns(splits);
+
+    // Transfer from splitsPayer to splits beneficiaries
+    await Promise.all(
+      splits.map(async (split) => {
+        mockToken.transfer
+          .whenCalledWith(split.beneficiary, AMOUNT.mul(split.percent).div(maxSplitsPercent))
+          .returns(true);
+      }),
+    );
+
+    // Transfer leftover from splitsPayer to msg.sender
+    mockToken.transfer.whenCalledWith(caller.address, AMOUNT.div('2')).returns(true);
+
+    await expect(
+      jbSplitsPayer
+        .connect(caller)
+        .addToBalanceOf(0, mockToken.address, AMOUNT, DECIMALS, MEMO, METADATA),
+    )
+      .to.emit(jbSplitsPayer, 'AddToBalance')
+      .withArgs(
+        0,
+        caller.address,
+        mockToken.address,
+        AMOUNT,
+        DECIMALS,
+        AMOUNT.div('2'), //leftover
+        MEMO,
+        METADATA,
+        caller.address,
+      );
+  });
+
+  it(`Cannot send ETH with another token as argument`, async function () {
+    const { jbSplitsPayer, mockToken } = await setup();
+
+    await expect(
+      jbSplitsPayer.addToBalanceOf(
+        PROJECT_ID,
+        mockToken.address,
+        AMOUNT,
+        DECIMALS,
+        MEMO,
+        METADATA,
+        {
+          value: AMOUNT,
+        },
+      ),
+    ).to.be.revertedWith(errors.NO_MSG_VALUE_ALLOWED);
+  });
+});

--- a/test/jb_eth_erc20_splits_payer_deployer/deploy_split_payer.test.js
+++ b/test/jb_eth_erc20_splits_payer_deployer/deploy_split_payer.test.js
@@ -22,12 +22,15 @@ describe('JBSplitsPayerDeployer::deploySplitsPayer(...)', function () {
 
     let mockJbDirectory = await deployMockContract(deployer, jbDirectory.abi);
     let mockJbSplitsStore = await deployMockContract(deployer, jbSplitsStore.abi);
+    await mockJbSplitsStore.mock.directory.returns(mockJbDirectory.address);
+
     let jbSplitsPayerDeployerFactory = await ethers.getContractFactory(
       'contracts/JBETHERC20SplitsPayerDeployer.sol:JBETHERC20SplitsPayerDeployer',
     );
-    let jbSplitsPayerDeployer = await jbSplitsPayerDeployerFactory.deploy();
 
-    await mockJbSplitsStore.mock.directory.returns(mockJbDirectory.address);
+    let jbSplitsPayerDeployer = await jbSplitsPayerDeployerFactory.deploy(
+      mockJbSplitsStore.address,
+    );
 
     return {
       deployer,
@@ -52,7 +55,6 @@ describe('JBSplitsPayerDeployer::deploySplitsPayer(...)', function () {
         DEFAULT_SPLITS_PROJECT_ID,
         DEFAULT_SPLITS_DOMAIN,
         DEFAULT_SPLITS_GROUP,
-        mockJbSplitsStore.address,
         DEFAULT_PROJECT_ID,
         DEFAULT_BENEFICIARY,
         DEFAULT_PREFER_CLAIMED_TOKENS,

--- a/test/jb_eth_erc20_splits_payer_deployer/deploy_split_payer_with_splits.test.js
+++ b/test/jb_eth_erc20_splits_payer_deployer/deploy_split_payer_with_splits.test.js
@@ -23,12 +23,15 @@ describe('JBSplitsPayerDeployer::deploySplitsPayerWithSplits(...)', function () 
 
     let mockJbDirectory = await deployMockContract(deployer, jbDirectory.abi);
     let mockJbSplitsStore = await deployMockContract(deployer, jbSplitsStore.abi);
+    await mockJbSplitsStore.mock.directory.returns(mockJbDirectory.address);
+
     let jbSplitsPayerDeployerFactory = await ethers.getContractFactory(
       'contracts/JBETHERC20SplitsPayerDeployer.sol:JBETHERC20SplitsPayerDeployer',
     );
-    let jbSplitsPayerDeployer = await jbSplitsPayerDeployerFactory.deploy();
 
-    await mockJbSplitsStore.mock.directory.returns(mockJbDirectory.address);
+    let jbSplitsPayerDeployer = await jbSplitsPayerDeployerFactory.deploy(
+      mockJbSplitsStore.address,
+    );
 
     return {
       deployer,

--- a/test/jb_eth_erc20_splits_payer_deployer/pay.test.js
+++ b/test/jb_eth_erc20_splits_payer_deployer/pay.test.js
@@ -66,17 +66,37 @@ describe('JBETHERC20SplitsPayer with Proxy::pay(...)', function () {
     let mockJbTerminal = await deployMockContract(deployer, jbTerminal.abi);
     let mockToken = await smock.fake(ierc20.abi);
 
-    let jbSplitsPayerFactory = await ethers.getContractFactory(
-      'contracts/JBETHERC20SplitsPayer.sol:JBETHERC20SplitsPayer',
-    );
-
     await mockJbSplitsStore.mock.directory.returns(mockJbDirectory.address);
 
-    let jbSplitsPayer = await jbSplitsPayerFactory.deploy(
+    let jbSplitsPayerDeployerFactory = await ethers.getContractFactory(
+      'contracts/JBETHERC20SplitsPayerDeployer.sol:JBETHERC20SplitsPayerDeployer',
+    );
+
+    let jbSplitsPayerDeployer = await jbSplitsPayerDeployerFactory.deploy(
+      mockJbSplitsStore.address,
+    );
+
+    let jbSplitsPayerFactory = await ethers.getContractFactory('JBETHERC20SplitsPayer');
+
+    let jbSplitsPayer = jbSplitsPayerFactory.attach(
+      await jbSplitsPayerDeployer.callStatic.deploySplitsPayer(
+        DEFAULT_SPLITS_PROJECT_ID,
+        DEFAULT_SPLITS_DOMAIN,
+        DEFAULT_SPLITS_GROUP,
+        DEFAULT_PROJECT_ID,
+        DEFAULT_BENEFICIARY,
+        DEFAULT_PREFER_CLAIMED_TOKENS,
+        DEFAULT_MEMO,
+        DEFAULT_METADATA,
+        PREFER_ADD_TO_BALANCE,
+        owner.address,
+      ),
+    );
+
+    await jbSplitsPayerDeployer.deploySplitsPayer(
       DEFAULT_SPLITS_PROJECT_ID,
       DEFAULT_SPLITS_DOMAIN,
       DEFAULT_SPLITS_GROUP,
-      mockJbSplitsStore.address,
       DEFAULT_PROJECT_ID,
       DEFAULT_BENEFICIARY,
       DEFAULT_PREFER_CLAIMED_TOKENS,
@@ -101,6 +121,7 @@ describe('JBETHERC20SplitsPayer with Proxy::pay(...)', function () {
       mockJbSplitsStore,
       jbSplitsPayer,
       jbSplitsPayerFactory,
+      jbSplitsPayerDeployer,
     };
   }
 
@@ -760,15 +781,30 @@ describe('JBETHERC20SplitsPayer with Proxy::pay(...)', function () {
   });
 
   it(`Should send fund directly to the caller, if no allocator, project ID, beneficiary or default beneficiary is set, and emit event`, async function () {
-    const { caller, jbSplitsPayerFactory, mockJbSplitsStore, owner } = await setup();
+    const { caller, jbSplitsPayerFactory, jbSplitsPayerDeployer, mockJbSplitsStore, owner } =
+      await setup();
 
     let splits = makeSplits();
 
-    let jbSplitsPayerWithoutDefaultBeneficiary = await jbSplitsPayerFactory.deploy(
+    let jbSplitsPayerWithoutDefaultBeneficiary = jbSplitsPayerFactory.attach(
+      await jbSplitsPayerDeployer.callStatic.deploySplitsPayer(
+        DEFAULT_SPLITS_PROJECT_ID,
+        DEFAULT_SPLITS_DOMAIN,
+        DEFAULT_SPLITS_GROUP,
+        DEFAULT_PROJECT_ID,
+        ethers.constants.AddressZero,
+        DEFAULT_PREFER_CLAIMED_TOKENS,
+        DEFAULT_MEMO,
+        DEFAULT_METADATA,
+        PREFER_ADD_TO_BALANCE,
+        owner.address,
+      ),
+    );
+
+    await jbSplitsPayerDeployer.deploySplitsPayer(
       DEFAULT_SPLITS_PROJECT_ID,
       DEFAULT_SPLITS_DOMAIN,
       DEFAULT_SPLITS_GROUP,
-      mockJbSplitsStore.address,
       DEFAULT_PROJECT_ID,
       ethers.constants.AddressZero,
       DEFAULT_PREFER_CLAIMED_TOKENS,
@@ -1163,6 +1199,7 @@ describe('JBETHERC20SplitsPayer with Proxy::pay(...)', function () {
       caller,
       owner,
       jbSplitsPayerFactory,
+      jbSplitsPayerDeployer,
       mockJbDirectory,
       mockJbSplitsStore,
       mockJbTerminal,
@@ -1178,11 +1215,25 @@ describe('JBETHERC20SplitsPayer with Proxy::pay(...)', function () {
       percent: maxSplitsPercent.div('4'),
     });
 
-    let jbSplitsPayerWithoutDefaultBeneficiary = await jbSplitsPayerFactory.deploy(
+    let jbSplitsPayerWithoutDefaultBeneficiary = jbSplitsPayerFactory.attach(
+      await jbSplitsPayerDeployer.callStatic.deploySplitsPayer(
+        DEFAULT_SPLITS_PROJECT_ID,
+        DEFAULT_SPLITS_DOMAIN,
+        DEFAULT_SPLITS_GROUP,
+        DEFAULT_PROJECT_ID,
+        ethers.constants.AddressZero,
+        DEFAULT_PREFER_CLAIMED_TOKENS,
+        DEFAULT_MEMO,
+        DEFAULT_METADATA,
+        PREFER_ADD_TO_BALANCE,
+        owner.address,
+      ),
+    );
+
+    await jbSplitsPayerDeployer.deploySplitsPayer(
       DEFAULT_SPLITS_PROJECT_ID,
       DEFAULT_SPLITS_DOMAIN,
       DEFAULT_SPLITS_GROUP,
-      mockJbSplitsStore.address,
       DEFAULT_PROJECT_ID,
       ethers.constants.AddressZero,
       DEFAULT_PREFER_CLAIMED_TOKENS,
@@ -1249,6 +1300,7 @@ describe('JBETHERC20SplitsPayer with Proxy::pay(...)', function () {
       caller,
       owner,
       jbSplitsPayerFactory,
+      jbSplitsPayerDeployer,
       mockJbSplitsStore,
       mockToken,
       beneficiaryOne,
@@ -1263,11 +1315,25 @@ describe('JBETHERC20SplitsPayer with Proxy::pay(...)', function () {
       percent: maxSplitsPercent.div('4'),
     });
 
-    let jbSplitsPayerWithoutDefaultBeneficiary = await jbSplitsPayerFactory.deploy(
+    let jbSplitsPayerWithoutDefaultBeneficiary = jbSplitsPayerFactory.attach(
+      await jbSplitsPayerDeployer.callStatic.deploySplitsPayer(
+        DEFAULT_SPLITS_PROJECT_ID,
+        DEFAULT_SPLITS_DOMAIN,
+        DEFAULT_SPLITS_GROUP,
+        DEFAULT_PROJECT_ID,
+        ethers.constants.AddressZero,
+        DEFAULT_PREFER_CLAIMED_TOKENS,
+        DEFAULT_MEMO,
+        DEFAULT_METADATA,
+        PREFER_ADD_TO_BALANCE,
+        owner.address,
+      ),
+    );
+
+    await jbSplitsPayerDeployer.deploySplitsPayer(
       DEFAULT_SPLITS_PROJECT_ID,
       DEFAULT_SPLITS_DOMAIN,
       DEFAULT_SPLITS_GROUP,
-      mockJbSplitsStore.address,
       DEFAULT_PROJECT_ID,
       ethers.constants.AddressZero,
       DEFAULT_PREFER_CLAIMED_TOKENS,

--- a/test/jb_eth_erc20_splits_payer_deployer/pay.test.js
+++ b/test/jb_eth_erc20_splits_payer_deployer/pay.test.js
@@ -1,0 +1,1399 @@
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { makeSplits } from '../helpers/utils.js';
+import { smock } from '@defi-wonderland/smock';
+
+import { deployMockContract } from '@ethereum-waffle/mock-contract';
+
+import errors from '../helpers/errors.json';
+import ierc20 from '../../artifacts/@openzeppelin/contracts/token/ERC20/ERC20.sol/ERC20.json';
+import jbAllocator from '../../artifacts/contracts/interfaces/IJBSplitAllocator.sol/IJBSplitAllocator.json';
+import jbDirectory from '../../artifacts/contracts/JBDirectory.sol/JBDirectory.json';
+import jbSplitsStore from '../../artifacts/contracts/JBSplitsStore.sol/JBSplitsStore.json';
+import jbTerminal from '../../artifacts/contracts/abstract/JBPayoutRedemptionPaymentTerminal.sol/JBPayoutRedemptionPaymentTerminal.json';
+
+describe('JBETHERC20SplitsPayer with Proxy::pay(...)', function () {
+  const DEFAULT_PROJECT_ID = 2;
+  const DEFAULT_SPLITS_PROJECT_ID = 3;
+  const DEFAULT_SPLITS_DOMAIN = 1;
+  const DEFAULT_SPLITS_GROUP = 1;
+  const DECIMALS = 18;
+  let DEFAULT_BENEFICIARY;
+  const DEFAULT_PREFER_CLAIMED_TOKENS = false;
+  const DEFAULT_MEMO = 'hello world';
+  const DEFAULT_METADATA = '0x42';
+
+  const PROJECT_ID = 69;
+  const AMOUNT = ethers.utils.parseEther('1.0');
+  const PREFER_ADD_TO_BALANCE = false;
+  const BENEFICIARY = ethers.Wallet.createRandom().address;
+  const PREFER_CLAIMED_TOKENS = true;
+  const MIN_RETURNED_TOKENS = 1;
+  const MEMO = 'hi world';
+  const METADATA = '0x69';
+
+  let ethToken;
+  let maxSplitsPercent;
+
+  this.beforeAll(async function () {
+    let jbTokensFactory = await ethers.getContractFactory('JBTokens');
+    let jbTokens = await jbTokensFactory.deploy();
+
+    ethToken = await jbTokens.ETH();
+
+    let jbConstantsFactory = await ethers.getContractFactory('JBConstants');
+    let jbConstants = await jbConstantsFactory.deploy();
+
+    maxSplitsPercent = await jbConstants.SPLITS_TOTAL_PERCENT();
+  });
+
+  async function setup() {
+    let [
+      deployer,
+      owner,
+      caller,
+      beneficiaryOne,
+      beneficiaryTwo,
+      beneficiaryThree,
+      defaultBeneficiarySigner,
+      ...addrs
+    ] = await ethers.getSigners();
+
+    DEFAULT_BENEFICIARY = defaultBeneficiarySigner.address;
+
+    let mockJbDirectory = await deployMockContract(deployer, jbDirectory.abi);
+    let mockJbSplitsStore = await deployMockContract(deployer, jbSplitsStore.abi);
+    let mockJbTerminal = await deployMockContract(deployer, jbTerminal.abi);
+    let mockToken = await smock.fake(ierc20.abi);
+
+    let jbSplitsPayerFactory = await ethers.getContractFactory(
+      'contracts/JBETHERC20SplitsPayer.sol:JBETHERC20SplitsPayer',
+    );
+
+    await mockJbSplitsStore.mock.directory.returns(mockJbDirectory.address);
+
+    let jbSplitsPayer = await jbSplitsPayerFactory.deploy(
+      DEFAULT_SPLITS_PROJECT_ID,
+      DEFAULT_SPLITS_DOMAIN,
+      DEFAULT_SPLITS_GROUP,
+      mockJbSplitsStore.address,
+      DEFAULT_PROJECT_ID,
+      DEFAULT_BENEFICIARY,
+      DEFAULT_PREFER_CLAIMED_TOKENS,
+      DEFAULT_MEMO,
+      DEFAULT_METADATA,
+      PREFER_ADD_TO_BALANCE,
+      owner.address,
+    );
+
+    return {
+      beneficiaryOne,
+      beneficiaryTwo,
+      beneficiaryThree,
+      defaultBeneficiarySigner,
+      deployer,
+      caller,
+      owner,
+      addrs,
+      mockToken,
+      mockJbDirectory,
+      mockJbTerminal,
+      mockJbSplitsStore,
+      jbSplitsPayer,
+      jbSplitsPayerFactory,
+    };
+  }
+
+  it(`Should send ETH towards allocator if set in split and emit event`, async function () {
+    const { deployer, caller, jbSplitsPayer, mockJbSplitsStore } = await setup();
+
+    let mockJbAllocator = await deployMockContract(deployer, jbAllocator.abi);
+
+    let splits = makeSplits({
+      count: 2,
+      projectId: PROJECT_ID,
+      allocator: mockJbAllocator.address,
+    });
+
+    await Promise.all(
+      splits.map(async (split) => {
+        await mockJbAllocator.mock.allocate
+          .withArgs({
+            token: ethToken,
+            amount: AMOUNT.mul(split.percent).div(maxSplitsPercent),
+            decimals: 18,
+            projectId: DEFAULT_PROJECT_ID,
+            group: 0,
+            split: split,
+          })
+          .returns();
+      }),
+    );
+
+    // Payment routing
+    await mockJbSplitsStore.mock.splitsOf
+      .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
+      .returns(splits);
+
+    let tx = jbSplitsPayer
+      .connect(caller)
+      .pay(
+        PROJECT_ID,
+        ethToken,
+        AMOUNT,
+        DECIMALS,
+        BENEFICIARY,
+        MIN_RETURNED_TOKENS,
+        PREFER_CLAIMED_TOKENS,
+        MEMO,
+        METADATA,
+        {
+          value: AMOUNT,
+        },
+      );
+
+    await expect(tx).emit(jbSplitsPayer, 'Pay').withArgs(
+      PROJECT_ID,
+      BENEFICIARY,
+      ethToken,
+      AMOUNT,
+      18,
+      0, //left over
+      MIN_RETURNED_TOKENS,
+      PREFER_CLAIMED_TOKENS,
+      MEMO,
+      METADATA,
+      caller.address,
+    );
+
+    await Promise.all(
+      splits.map(async (split) => {
+        await expect(tx)
+          .to.emit(jbSplitsPayer, 'DistributeToSplit')
+          .withArgs(
+            [
+              split.preferClaimed,
+              split.preferAddToBalance,
+              split.percent,
+              split.projectId,
+              split.beneficiary,
+              split.lockedUntil,
+              split.allocator,
+            ],
+            AMOUNT.mul(split.percent).div(maxSplitsPercent),
+            DEFAULT_BENEFICIARY,
+            caller.address,
+          );
+      }),
+    );
+
+    await expect(tx)
+      .to.emit(jbSplitsPayer, 'DistributeToSplitGroup')
+      .withArgs(
+        DEFAULT_SPLITS_PROJECT_ID,
+        DEFAULT_SPLITS_DOMAIN,
+        DEFAULT_SPLITS_GROUP,
+        caller.address,
+      );
+  });
+
+  it(`Should send ERC20 with 9-decimals towards allocator if set in split and emit event`, async function () {
+    const { caller, deployer, jbSplitsPayer, mockToken, mockJbSplitsStore } = await setup();
+    const DECIMALS = 9;
+
+    let mockJbAllocator = await deployMockContract(deployer, jbAllocator.abi);
+
+    let splits = makeSplits({ projectId: PROJECT_ID, allocator: mockJbAllocator.address });
+
+    await Promise.all(
+      splits.map(async (split) => {
+        mockToken.allowance
+          .whenCalledWith(jbSplitsPayer.address, mockJbAllocator.address)
+          .returns(0);
+
+        mockToken.approve
+          .whenCalledWith(mockJbAllocator.address, AMOUNT.mul(split.percent).div(maxSplitsPercent))
+          .returns(true);
+
+        await mockJbAllocator.mock.allocate
+          .withArgs({
+            token: mockToken.address,
+            amount: AMOUNT.mul(split.percent).div(maxSplitsPercent),
+            decimals: DECIMALS,
+            projectId: DEFAULT_PROJECT_ID,
+            group: 0,
+            split: split,
+          })
+          .returns();
+      }),
+    );
+
+    await mockJbSplitsStore.mock.splitsOf
+      .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
+      .returns(splits);
+
+    mockToken.balanceOf.returnsAtCall(0, 0);
+
+    mockToken.transferFrom
+      .whenCalledWith(caller.address, jbSplitsPayer.address, AMOUNT)
+      .returns(true);
+
+    mockToken.balanceOf.returnsAtCall(1, AMOUNT);
+
+    let tx = jbSplitsPayer
+      .connect(caller)
+      .pay(
+        PROJECT_ID,
+        mockToken.address,
+        AMOUNT,
+        DECIMALS,
+        BENEFICIARY,
+        MIN_RETURNED_TOKENS,
+        PREFER_CLAIMED_TOKENS,
+        MEMO,
+        METADATA,
+      );
+
+    await expect(tx).to.emit(jbSplitsPayer, 'Pay').withArgs(
+      PROJECT_ID,
+      BENEFICIARY,
+      mockToken.address,
+      AMOUNT,
+      DECIMALS,
+      0, //left over
+      MIN_RETURNED_TOKENS,
+      PREFER_CLAIMED_TOKENS,
+      MEMO,
+      METADATA,
+      caller.address,
+    );
+  });
+
+  it(`Should send ERC20 with 9-decimals towards allocator supporting fee on transfer token`, async function () {
+    const { caller, deployer, jbSplitsPayer, mockToken, mockJbSplitsStore } = await setup();
+    const DECIMALS = 9;
+    const NET_AMOUNT = AMOUNT.sub(100);
+
+    let mockJbAllocator = await deployMockContract(deployer, jbAllocator.abi);
+
+    let splits = makeSplits({ projectId: PROJECT_ID, allocator: mockJbAllocator.address });
+
+    await Promise.all(
+      splits.map(async (split) => {
+        mockToken.allowance
+          .whenCalledWith(jbSplitsPayer.address, mockJbAllocator.address)
+          .returns(0);
+
+        mockToken.approve
+          .whenCalledWith(
+            mockJbAllocator.address,
+            NET_AMOUNT.mul(split.percent).div(maxSplitsPercent),
+          )
+          .returns(true);
+
+        await mockJbAllocator.mock.allocate
+          .withArgs({
+            token: mockToken.address,
+            amount: NET_AMOUNT.mul(split.percent).div(maxSplitsPercent),
+            decimals: DECIMALS,
+            projectId: DEFAULT_PROJECT_ID,
+            group: 0,
+            split: split,
+          })
+          .returns();
+      }),
+    );
+
+    await mockJbSplitsStore.mock.splitsOf
+      .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
+      .returns(splits);
+
+    mockToken.balanceOf.returnsAtCall(0, 0);
+
+    mockToken.transferFrom
+      .whenCalledWith(caller.address, jbSplitsPayer.address, AMOUNT)
+      .returns(true);
+
+    mockToken.balanceOf.returnsAtCall(1, NET_AMOUNT);
+
+    let tx = jbSplitsPayer
+      .connect(caller)
+      .pay(
+        PROJECT_ID,
+        mockToken.address,
+        AMOUNT,
+        DECIMALS,
+        BENEFICIARY,
+        MIN_RETURNED_TOKENS,
+        PREFER_CLAIMED_TOKENS,
+        MEMO,
+        METADATA,
+      );
+
+    await expect(tx).to.emit(jbSplitsPayer, 'Pay').withArgs(
+      PROJECT_ID,
+      BENEFICIARY,
+      mockToken.address,
+      NET_AMOUNT,
+      DECIMALS,
+      0, //left over
+      MIN_RETURNED_TOKENS,
+      PREFER_CLAIMED_TOKENS,
+      MEMO,
+      METADATA,
+      caller.address,
+    );
+  });
+
+  it(`Should send fund towards project terminal if project ID is set in split and add to balance if it is prefered, and emit event`, async function () {
+    const { caller, jbSplitsPayer, mockJbSplitsStore, mockJbDirectory, mockJbTerminal } =
+      await setup();
+
+    let splits = makeSplits({ projectId: PROJECT_ID, preferAddToBalance: true });
+
+    await mockJbDirectory.mock.primaryTerminalOf
+      .withArgs(PROJECT_ID, ethToken)
+      .returns(mockJbTerminal.address);
+
+    await mockJbTerminal.mock.decimalsForToken.withArgs(ethToken).returns(18);
+
+    await Promise.all(
+      splits.map(async (split) => {
+        await mockJbTerminal.mock.addToBalanceOf
+          .withArgs(
+            split.projectId,
+            AMOUNT.mul(split.percent).div(maxSplitsPercent),
+            ethToken,
+            DEFAULT_MEMO,
+            DEFAULT_METADATA,
+          )
+          .returns();
+      }),
+    );
+
+    await mockJbSplitsStore.mock.splitsOf
+      .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
+      .returns(splits);
+
+    let tx = jbSplitsPayer
+      .connect(caller)
+      .pay(
+        PROJECT_ID,
+        ethToken,
+        AMOUNT,
+        DECIMALS,
+        BENEFICIARY,
+        MIN_RETURNED_TOKENS,
+        PREFER_CLAIMED_TOKENS,
+        MEMO,
+        METADATA,
+        {
+          value: AMOUNT,
+        },
+      );
+
+    await expect(tx).to.emit(jbSplitsPayer, 'Pay').withArgs(
+      PROJECT_ID,
+      BENEFICIARY,
+      ethToken,
+      AMOUNT,
+      18,
+      0, //left over
+      MIN_RETURNED_TOKENS,
+      PREFER_CLAIMED_TOKENS,
+      MEMO,
+      METADATA,
+      caller.address,
+    );
+  });
+
+  it(`Should send fund towards project terminal if project ID is set in split, using pay with beneficiaries set in splits, and emit event`, async function () {
+    const {
+      caller,
+      beneficiaryOne,
+      beneficiaryTwo,
+      jbSplitsPayer,
+      mockJbSplitsStore,
+      mockJbDirectory,
+      mockJbTerminal,
+    } = await setup();
+    let splits = makeSplits({
+      count: 2,
+      projectId: PROJECT_ID,
+      beneficiary: [beneficiaryOne.address, beneficiaryTwo.address],
+    });
+
+    await mockJbDirectory.mock.primaryTerminalOf
+      .withArgs(PROJECT_ID, ethToken)
+      .returns(mockJbTerminal.address);
+
+    await mockJbTerminal.mock.decimalsForToken.withArgs(ethToken).returns(18);
+
+    await Promise.all(
+      splits.map(async (split) => {
+        await mockJbTerminal.mock.pay
+          .withArgs(
+            split.projectId,
+            AMOUNT.mul(split.percent).div(maxSplitsPercent),
+            ethToken,
+            split.beneficiary,
+            0 /*hardcoded*/,
+            split.preferClaimed,
+            DEFAULT_MEMO,
+            DEFAULT_METADATA,
+          )
+          .returns(0); // Not used
+      }),
+    );
+
+    await mockJbSplitsStore.mock.splitsOf
+      .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
+      .returns(splits);
+
+    let tx = jbSplitsPayer
+      .connect(caller)
+      .pay(
+        PROJECT_ID,
+        ethToken,
+        AMOUNT,
+        DECIMALS,
+        BENEFICIARY,
+        MIN_RETURNED_TOKENS,
+        PREFER_CLAIMED_TOKENS,
+        MEMO,
+        METADATA,
+        {
+          value: AMOUNT,
+        },
+      );
+    await expect(tx).to.emit(jbSplitsPayer, 'Pay').withArgs(
+      PROJECT_ID,
+      BENEFICIARY,
+      ethToken,
+      AMOUNT,
+      18,
+      0, //left over
+      MIN_RETURNED_TOKENS,
+      PREFER_CLAIMED_TOKENS,
+      MEMO,
+      METADATA,
+      caller.address,
+    );
+    await Promise.all(
+      splits.map(async (split) => {
+        await expect(tx)
+          .to.emit(jbSplitsPayer, 'DistributeToSplit')
+          .withArgs(
+            [
+              split.preferClaimed,
+              split.preferAddToBalance,
+              split.percent,
+              split.projectId,
+              split.beneficiary,
+              split.lockedUntil,
+              split.allocator,
+            ],
+            AMOUNT.mul(split.percent).div(maxSplitsPercent),
+            DEFAULT_BENEFICIARY,
+            caller.address,
+          );
+      }),
+    );
+
+    await expect(tx)
+      .to.emit(jbSplitsPayer, 'DistributeToSplitGroup')
+      .withArgs(
+        DEFAULT_SPLITS_PROJECT_ID,
+        DEFAULT_SPLITS_DOMAIN,
+        DEFAULT_SPLITS_GROUP,
+        caller.address,
+      );
+  });
+
+  it(`Should send fund towards project terminal if project ID is set in split, using pay with the default beneficiary if none is set in splits and emit event`, async function () {
+    const { caller, jbSplitsPayer, mockJbSplitsStore, mockJbDirectory, mockJbTerminal } =
+      await setup();
+
+    let splits = makeSplits({ projectId: PROJECT_ID });
+
+    await mockJbDirectory.mock.primaryTerminalOf
+      .withArgs(PROJECT_ID, ethToken)
+      .returns(mockJbTerminal.address);
+
+    await mockJbTerminal.mock.decimalsForToken.withArgs(ethToken).returns(18);
+
+    await Promise.all(
+      splits.map(async (split) => {
+        await mockJbTerminal.mock.pay
+          .withArgs(
+            split.projectId,
+            AMOUNT.mul(split.percent).div(maxSplitsPercent),
+            ethToken,
+            DEFAULT_BENEFICIARY,
+            0 /*hardcoded*/,
+            split.preferClaimed,
+            DEFAULT_MEMO,
+            DEFAULT_METADATA,
+          )
+          .returns(0); // Not used
+      }),
+    );
+
+    await mockJbSplitsStore.mock.splitsOf
+      .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
+      .returns(splits);
+
+    let tx = jbSplitsPayer
+      .connect(caller)
+      .pay(
+        PROJECT_ID,
+        ethToken,
+        AMOUNT,
+        DECIMALS,
+        BENEFICIARY,
+        MIN_RETURNED_TOKENS,
+        PREFER_CLAIMED_TOKENS,
+        MEMO,
+        METADATA,
+        {
+          value: AMOUNT,
+        },
+      );
+    await expect(tx).to.emit(jbSplitsPayer, 'Pay').withArgs(
+      PROJECT_ID,
+      BENEFICIARY,
+      ethToken,
+      AMOUNT,
+      18,
+      0, //left over
+      MIN_RETURNED_TOKENS,
+      PREFER_CLAIMED_TOKENS,
+      MEMO,
+      METADATA,
+      caller.address,
+    );
+
+    await Promise.all(
+      splits.map(async (split) => {
+        await expect(tx)
+          .to.emit(jbSplitsPayer, 'DistributeToSplit')
+          .withArgs(
+            [
+              split.preferClaimed,
+              split.preferAddToBalance,
+              split.percent,
+              split.projectId,
+              split.beneficiary,
+              split.lockedUntil,
+              split.allocator,
+            ],
+            AMOUNT.mul(split.percent).div(maxSplitsPercent),
+            DEFAULT_BENEFICIARY,
+            caller.address,
+          );
+      }),
+    );
+
+    await expect(tx)
+      .to.emit(jbSplitsPayer, 'DistributeToSplitGroup')
+      .withArgs(
+        DEFAULT_SPLITS_PROJECT_ID,
+        DEFAULT_SPLITS_DOMAIN,
+        DEFAULT_SPLITS_GROUP,
+        caller.address,
+      );
+  });
+
+  it(`Should send fund directly to a beneficiary set in split, if no allocator or project ID is set in splits and emit event`, async function () {
+    const { caller, beneficiaryOne, beneficiaryTwo, jbSplitsPayer, mockJbSplitsStore } =
+      await setup();
+
+    let splits = makeSplits({
+      count: 2,
+      beneficiary: [beneficiaryOne.address, beneficiaryTwo.address],
+    });
+
+    await mockJbSplitsStore.mock.splitsOf
+      .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
+      .returns(splits);
+
+    let tx = await jbSplitsPayer
+      .connect(caller)
+      .pay(
+        PROJECT_ID,
+        ethToken,
+        AMOUNT,
+        DECIMALS,
+        BENEFICIARY,
+        MIN_RETURNED_TOKENS,
+        PREFER_CLAIMED_TOKENS,
+        MEMO,
+        METADATA,
+        {
+          value: AMOUNT,
+        },
+      );
+
+    await expect(tx).to.changeEtherBalance(
+      beneficiaryOne,
+      AMOUNT.mul(splits[0].percent).div(maxSplitsPercent),
+    );
+    await expect(tx).to.changeEtherBalance(
+      beneficiaryTwo,
+      AMOUNT.mul(splits[0].percent).div(maxSplitsPercent),
+    );
+
+    await expect(tx).to.emit(jbSplitsPayer, 'Pay').withArgs(
+      PROJECT_ID,
+      BENEFICIARY,
+      ethToken,
+      AMOUNT,
+      18,
+      0, //left over
+      MIN_RETURNED_TOKENS,
+      PREFER_CLAIMED_TOKENS,
+      MEMO,
+      METADATA,
+      caller.address,
+    );
+
+    await Promise.all(
+      splits.map(async (split) => {
+        await expect(tx)
+          .to.emit(jbSplitsPayer, 'DistributeToSplit')
+          .withArgs(
+            [
+              split.preferClaimed,
+              split.preferAddToBalance,
+              split.percent,
+              split.projectId,
+              split.beneficiary,
+              split.lockedUntil,
+              split.allocator,
+            ],
+            AMOUNT.mul(split.percent).div(maxSplitsPercent),
+            DEFAULT_BENEFICIARY,
+            caller.address,
+          );
+      }),
+    );
+
+    await expect(tx)
+      .to.emit(jbSplitsPayer, 'DistributeToSplitGroup')
+      .withArgs(
+        DEFAULT_SPLITS_PROJECT_ID,
+        DEFAULT_SPLITS_DOMAIN,
+        DEFAULT_SPLITS_GROUP,
+        caller.address,
+      );
+  });
+
+  it(`Should send fund directly to the default beneficiary, if no allocator, project ID or beneficiary is set, and emit event`, async function () {
+    const { caller, jbSplitsPayer, mockJbSplitsStore, defaultBeneficiarySigner } = await setup();
+
+    let splits = makeSplits();
+
+    await mockJbSplitsStore.mock.splitsOf
+      .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
+      .returns(splits);
+
+    let tx = await jbSplitsPayer
+      .connect(caller)
+      .pay(
+        PROJECT_ID,
+        ethToken,
+        AMOUNT,
+        DECIMALS,
+        ethers.constants.AddressZero,
+        MIN_RETURNED_TOKENS,
+        PREFER_CLAIMED_TOKENS,
+        MEMO,
+        METADATA,
+        {
+          value: AMOUNT,
+        },
+      );
+
+    await expect(tx).to.changeEtherBalance(defaultBeneficiarySigner, AMOUNT);
+    await expect(tx).to.emit(jbSplitsPayer, 'Pay').withArgs(
+      PROJECT_ID,
+      DEFAULT_BENEFICIARY,
+      ethToken,
+      AMOUNT,
+      18,
+      0, //left over
+      MIN_RETURNED_TOKENS,
+      PREFER_CLAIMED_TOKENS,
+      MEMO,
+      METADATA,
+      caller.address,
+    );
+    await Promise.all(
+      splits.map(async (split) => {
+        await expect(tx)
+          .to.emit(jbSplitsPayer, 'DistributeToSplit')
+          .withArgs(
+            [
+              split.preferClaimed,
+              split.preferAddToBalance,
+              split.percent,
+              split.projectId,
+              split.beneficiary,
+              split.lockedUntil,
+              split.allocator,
+            ],
+            AMOUNT.mul(split.percent).div(maxSplitsPercent),
+            DEFAULT_BENEFICIARY,
+            caller.address,
+          );
+      }),
+    );
+
+    await expect(tx)
+      .to.emit(jbSplitsPayer, 'DistributeToSplitGroup')
+      .withArgs(
+        DEFAULT_SPLITS_PROJECT_ID,
+        DEFAULT_SPLITS_DOMAIN,
+        DEFAULT_SPLITS_GROUP,
+        caller.address,
+      );
+  });
+
+  it(`Should send fund directly to the caller, if no allocator, project ID, beneficiary or default beneficiary is set, and emit event`, async function () {
+    const { caller, jbSplitsPayerFactory, mockJbSplitsStore, owner } = await setup();
+
+    let splits = makeSplits();
+
+    let jbSplitsPayerWithoutDefaultBeneficiary = await jbSplitsPayerFactory.deploy(
+      DEFAULT_SPLITS_PROJECT_ID,
+      DEFAULT_SPLITS_DOMAIN,
+      DEFAULT_SPLITS_GROUP,
+      mockJbSplitsStore.address,
+      DEFAULT_PROJECT_ID,
+      ethers.constants.AddressZero,
+      DEFAULT_PREFER_CLAIMED_TOKENS,
+      DEFAULT_MEMO,
+      DEFAULT_METADATA,
+      PREFER_ADD_TO_BALANCE,
+      owner.address,
+    );
+
+    await mockJbSplitsStore.mock.splitsOf
+      .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
+      .returns(splits);
+
+    let tx = await jbSplitsPayerWithoutDefaultBeneficiary
+      .connect(caller)
+      .pay(
+        PROJECT_ID,
+        ethToken,
+        AMOUNT,
+        DECIMALS,
+        ethers.constants.AddressZero,
+        MIN_RETURNED_TOKENS,
+        PREFER_CLAIMED_TOKENS,
+        MEMO,
+        METADATA,
+        {
+          value: AMOUNT,
+        },
+      );
+
+    await expect(tx).to.changeEtherBalance(caller, 0); // -AMOUNT then +AMOUNT, gas is not taken into account
+    await expect(tx).to.emit(jbSplitsPayerWithoutDefaultBeneficiary, 'Pay').withArgs(
+      PROJECT_ID,
+      caller.address,
+      ethToken,
+      AMOUNT,
+      18,
+      0, //left over
+      MIN_RETURNED_TOKENS,
+      PREFER_CLAIMED_TOKENS,
+      MEMO,
+      METADATA,
+      caller.address,
+    );
+    await Promise.all(
+      splits.map(async (split) => {
+        await expect(tx)
+          .to.emit(jbSplitsPayerWithoutDefaultBeneficiary, 'DistributeToSplit')
+          .withArgs(
+            [
+              split.preferClaimed,
+              split.preferAddToBalance,
+              split.percent,
+              split.projectId,
+              split.beneficiary,
+              split.lockedUntil,
+              split.allocator,
+            ],
+            AMOUNT.mul(split.percent).div(maxSplitsPercent),
+            caller.address,
+            caller.address,
+          );
+      }),
+    );
+
+    await expect(tx)
+      .to.emit(jbSplitsPayerWithoutDefaultBeneficiary, 'DistributeToSplitGroup')
+      .withArgs(
+        DEFAULT_SPLITS_PROJECT_ID,
+        DEFAULT_SPLITS_DOMAIN,
+        DEFAULT_SPLITS_GROUP,
+        caller.address,
+      );
+  });
+
+  it(`Should send eth leftover to project id if set and emit event`, async function () {
+    const {
+      caller,
+      jbSplitsPayer,
+      mockJbDirectory,
+      mockJbSplitsStore,
+      mockJbTerminal,
+      beneficiaryOne,
+      beneficiaryTwo,
+      beneficiaryThree,
+    } = await setup();
+
+    // 50% to beneficiaries
+    let splits = makeSplits({
+      count: 2,
+      beneficiary: [beneficiaryOne.address, beneficiaryTwo.address],
+      percent: maxSplitsPercent.div('4'),
+    });
+
+    await mockJbSplitsStore.mock.splitsOf
+      .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
+      .returns(splits);
+
+    await mockJbTerminal.mock.decimalsForToken.withArgs(ethToken).returns(18);
+
+    await mockJbDirectory.mock.primaryTerminalOf
+      .withArgs(PROJECT_ID, ethToken)
+      .returns(mockJbTerminal.address);
+
+    await mockJbTerminal.mock.pay
+      .withArgs(
+        PROJECT_ID,
+        AMOUNT.div('2'),
+        ethToken,
+        beneficiaryThree.address,
+        MIN_RETURNED_TOKENS,
+        PREFER_CLAIMED_TOKENS,
+        MEMO,
+        METADATA,
+      )
+      .returns(0); // Not used
+
+    await expect(
+      jbSplitsPayer
+        .connect(caller)
+        .pay(
+          PROJECT_ID,
+          ethToken,
+          AMOUNT,
+          DECIMALS,
+          beneficiaryThree.address,
+          MIN_RETURNED_TOKENS,
+          PREFER_CLAIMED_TOKENS,
+          MEMO,
+          METADATA,
+          {
+            value: AMOUNT,
+          },
+        ),
+    )
+      .to.emit(jbSplitsPayer, 'Pay')
+      .withArgs(
+        PROJECT_ID,
+        beneficiaryThree.address,
+        ethToken,
+        AMOUNT,
+        18,
+        AMOUNT.div('2'), //left over
+        MIN_RETURNED_TOKENS,
+        PREFER_CLAIMED_TOKENS,
+        MEMO,
+        METADATA,
+        caller.address,
+      );
+  });
+
+  it(`Should send erc20 leftover to project id if set and emit event`, async function () {
+    const {
+      caller,
+      jbSplitsPayer,
+      mockJbDirectory,
+      mockJbSplitsStore,
+      mockJbTerminal,
+      mockToken,
+      beneficiaryOne,
+      beneficiaryTwo,
+      beneficiaryThree,
+    } = await setup();
+    // 50% to beneficiaries
+    let splits = makeSplits({
+      count: 2,
+      beneficiary: [beneficiaryOne.address, beneficiaryTwo.address],
+      percent: maxSplitsPercent.div('4'),
+    });
+
+    // Transfer to splitsPayer
+    mockToken.balanceOf.returnsAtCall(0, 0);
+
+    mockToken.transferFrom
+      .whenCalledWith(caller.address, jbSplitsPayer.address, AMOUNT)
+      .returns(true);
+
+    mockToken.balanceOf.returnsAtCall(1, AMOUNT);
+
+    await mockJbSplitsStore.mock.splitsOf
+      .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
+      .returns(splits);
+
+    // Transfer from splitsPayer to splits beneficiaries
+    await Promise.all(
+      splits.map(async (split) => {
+        mockToken.transfer
+          .whenCalledWith(split.beneficiary, AMOUNT.mul(split.percent).div(maxSplitsPercent))
+          .returns(true);
+      }),
+    );
+
+    // leftover: terminal of project ID
+    await mockJbDirectory.mock.primaryTerminalOf
+      .withArgs(PROJECT_ID, mockToken.address)
+      .returns(mockJbTerminal.address);
+
+    await mockJbTerminal.mock.decimalsForToken.withArgs(mockToken.address).returns(18);
+
+    // Approve transfer to the default project ID terminal
+    mockToken.allowance.whenCalledWith(jbSplitsPayer.address, mockJbTerminal.address).returns(0);
+    mockToken.approve.whenCalledWith(mockJbTerminal.address, AMOUNT.div('2')).returns(true);
+
+    // Pay the leftover with the default beneficiary
+    await mockJbTerminal.mock.pay
+      .withArgs(
+        PROJECT_ID,
+        AMOUNT.div('2'),
+        mockToken.address,
+        beneficiaryThree.address,
+        MIN_RETURNED_TOKENS,
+        PREFER_CLAIMED_TOKENS,
+        MEMO,
+        METADATA,
+      )
+      .returns(0); // Not used
+
+    await expect(
+      jbSplitsPayer.connect(caller).pay(
+        PROJECT_ID,
+        mockToken.address,
+        AMOUNT,
+        DECIMALS,
+        beneficiaryThree.address, // default beneficiary
+        MIN_RETURNED_TOKENS,
+        PREFER_CLAIMED_TOKENS,
+        MEMO,
+        METADATA,
+      ),
+    )
+      .to.emit(jbSplitsPayer, 'Pay')
+      .withArgs(
+        PROJECT_ID,
+        beneficiaryThree.address,
+        mockToken.address,
+        AMOUNT,
+        18,
+        AMOUNT.div('2'), //left over
+        MIN_RETURNED_TOKENS,
+        PREFER_CLAIMED_TOKENS,
+        MEMO,
+        METADATA,
+        caller.address,
+      );
+  });
+
+  it(`Should send eth leftover to beneficiary if no project id set and emit event`, async function () {
+    const {
+      caller,
+      jbSplitsPayer,
+      mockJbSplitsStore,
+      mockJbTerminal,
+      beneficiaryOne,
+      beneficiaryTwo,
+      beneficiaryThree,
+    } = await setup();
+
+    // 50% to beneficiaries
+    let splits = makeSplits({
+      count: 2,
+      beneficiary: [beneficiaryOne.address, beneficiaryTwo.address],
+      percent: maxSplitsPercent.div('4'),
+    });
+
+    await mockJbSplitsStore.mock.splitsOf
+      .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
+      .returns(splits);
+
+    await mockJbTerminal.mock.decimalsForToken.withArgs(ethToken).returns(18);
+
+    await mockJbTerminal.mock.pay
+      .withArgs(
+        0,
+        AMOUNT.div('2'),
+        ethToken,
+        beneficiaryThree.address,
+        MIN_RETURNED_TOKENS,
+        PREFER_CLAIMED_TOKENS,
+        MEMO,
+        METADATA,
+      )
+      .returns(0); // Not used
+
+    let tx = await jbSplitsPayer
+      .connect(caller)
+      .pay(
+        0,
+        ethToken,
+        AMOUNT,
+        DECIMALS,
+        beneficiaryThree.address,
+        MIN_RETURNED_TOKENS,
+        PREFER_CLAIMED_TOKENS,
+        MEMO,
+        METADATA,
+        {
+          value: AMOUNT,
+        },
+      );
+
+    await expect(tx).to.changeEtherBalance(beneficiaryThree, AMOUNT.div('2'));
+
+    await expect(tx).to.emit(jbSplitsPayer, 'Pay').withArgs(
+      0,
+      beneficiaryThree.address,
+      ethToken,
+      AMOUNT,
+      18,
+      AMOUNT.div('2'), //left over
+      MIN_RETURNED_TOKENS,
+      PREFER_CLAIMED_TOKENS,
+      MEMO,
+      METADATA,
+      caller.address,
+    );
+  });
+
+  it(`Should send erc20 leftover to beneficiary if no project id set and emit event`, async function () {
+    const {
+      caller,
+      jbSplitsPayer,
+      mockToken,
+      mockJbSplitsStore,
+      beneficiaryOne,
+      beneficiaryTwo,
+      beneficiaryThree,
+    } = await setup();
+
+    // 50% to beneficiaries
+    let splits = makeSplits({
+      count: 2,
+      beneficiary: [beneficiaryOne.address, beneficiaryTwo.address],
+      percent: maxSplitsPercent.div('4'),
+    });
+
+    // Transfer to splitsPayer
+    mockToken.balanceOf.returnsAtCall(0, 0);
+
+    mockToken.transferFrom
+      .whenCalledWith(caller.address, jbSplitsPayer.address, AMOUNT)
+      .returns(true);
+
+    mockToken.balanceOf.returnsAtCall(1, AMOUNT);
+
+    await mockJbSplitsStore.mock.splitsOf
+      .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
+      .returns(splits);
+
+    // Transfer from splitsPayer to splits beneficiaries
+    await Promise.all(
+      splits.map(async (split) => {
+        mockToken.transfer
+          .whenCalledWith(split.beneficiary, AMOUNT.mul(split.percent).div(maxSplitsPercent))
+          .returns(true);
+      }),
+    );
+
+    // Transfer from splitsPayer to default beneficiary
+    mockToken.transfer.whenCalledWith(beneficiaryThree.address, AMOUNT.div('2')).returns(true);
+
+    let tx = await jbSplitsPayer
+      .connect(caller)
+      .pay(
+        0,
+        mockToken.address,
+        AMOUNT,
+        DECIMALS,
+        beneficiaryThree.address,
+        MIN_RETURNED_TOKENS,
+        PREFER_CLAIMED_TOKENS,
+        MEMO,
+        METADATA,
+      );
+
+    await expect(tx).to.emit(jbSplitsPayer, 'Pay').withArgs(
+      0,
+      beneficiaryThree.address,
+      mockToken.address,
+      AMOUNT,
+      DECIMALS,
+      AMOUNT.div('2'), //left over
+      MIN_RETURNED_TOKENS,
+      PREFER_CLAIMED_TOKENS,
+      MEMO,
+      METADATA,
+      caller.address,
+    );
+  });
+
+  it(`Should send eth leftover to the caller if no project id nor beneficiary is set and emit event`, async function () {
+    const {
+      caller,
+      owner,
+      jbSplitsPayerFactory,
+      mockJbDirectory,
+      mockJbSplitsStore,
+      mockJbTerminal,
+      beneficiaryOne,
+      beneficiaryTwo,
+      beneficiaryThree,
+    } = await setup();
+
+    // 50% to beneficiaries
+    let splits = makeSplits({
+      count: 2,
+      beneficiary: [beneficiaryOne.address, beneficiaryTwo.address],
+      percent: maxSplitsPercent.div('4'),
+    });
+
+    let jbSplitsPayerWithoutDefaultBeneficiary = await jbSplitsPayerFactory.deploy(
+      DEFAULT_SPLITS_PROJECT_ID,
+      DEFAULT_SPLITS_DOMAIN,
+      DEFAULT_SPLITS_GROUP,
+      mockJbSplitsStore.address,
+      DEFAULT_PROJECT_ID,
+      ethers.constants.AddressZero,
+      DEFAULT_PREFER_CLAIMED_TOKENS,
+      DEFAULT_MEMO,
+      DEFAULT_METADATA,
+      PREFER_ADD_TO_BALANCE,
+      owner.address,
+    );
+
+    await mockJbSplitsStore.mock.splitsOf
+      .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
+      .returns(splits);
+
+    await mockJbTerminal.mock.decimalsForToken.withArgs(ethToken).returns(18);
+
+    await mockJbTerminal.mock.pay
+      .withArgs(
+        0,
+        AMOUNT.div('2'),
+        ethToken,
+        ethers.constants.AddressZero,
+        MIN_RETURNED_TOKENS,
+        PREFER_CLAIMED_TOKENS,
+        MEMO,
+        METADATA,
+      )
+      .returns(0); // Not used
+
+    let tx = await jbSplitsPayerWithoutDefaultBeneficiary
+      .connect(caller)
+      .pay(
+        0,
+        ethToken,
+        AMOUNT,
+        DECIMALS,
+        ethers.constants.AddressZero,
+        MIN_RETURNED_TOKENS,
+        PREFER_CLAIMED_TOKENS,
+        MEMO,
+        METADATA,
+        {
+          value: AMOUNT,
+        },
+      );
+
+    await expect(tx).to.changeEtherBalance(caller, AMOUNT.div('-2')); // Only 50% are dsitributed, rest is returned
+    await expect(tx).to.emit(jbSplitsPayerWithoutDefaultBeneficiary, 'Pay').withArgs(
+      0,
+      caller.address,
+      ethToken,
+      AMOUNT,
+      18,
+      AMOUNT.div('2'), //left over
+      MIN_RETURNED_TOKENS,
+      PREFER_CLAIMED_TOKENS,
+      MEMO,
+      METADATA,
+      caller.address,
+    );
+  });
+
+  it(`Should send erc20 leftover to the caller if no project id nor beneficiary is set and emit event`, async function () {
+    const {
+      caller,
+      owner,
+      jbSplitsPayerFactory,
+      mockJbSplitsStore,
+      mockToken,
+      beneficiaryOne,
+      beneficiaryTwo,
+      beneficiaryThree,
+    } = await setup();
+
+    // 50% to beneficiaries
+    let splits = makeSplits({
+      count: 2,
+      beneficiary: [beneficiaryOne.address, beneficiaryTwo.address],
+      percent: maxSplitsPercent.div('4'),
+    });
+
+    let jbSplitsPayerWithoutDefaultBeneficiary = await jbSplitsPayerFactory.deploy(
+      DEFAULT_SPLITS_PROJECT_ID,
+      DEFAULT_SPLITS_DOMAIN,
+      DEFAULT_SPLITS_GROUP,
+      mockJbSplitsStore.address,
+      DEFAULT_PROJECT_ID,
+      ethers.constants.AddressZero,
+      DEFAULT_PREFER_CLAIMED_TOKENS,
+      DEFAULT_MEMO,
+      DEFAULT_METADATA,
+      PREFER_ADD_TO_BALANCE,
+      owner.address,
+    );
+
+    // Transfer to splitsPayer
+    mockToken.balanceOf.returnsAtCall(0, 0);
+
+    mockToken.transferFrom
+      .whenCalledWith(caller.address, jbSplitsPayerWithoutDefaultBeneficiary.address, AMOUNT)
+      .returns(true);
+
+    mockToken.balanceOf.returnsAtCall(1, AMOUNT);
+
+    await mockJbSplitsStore.mock.splitsOf
+      .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
+      .returns(splits);
+
+    // Transfer from splitsPayer to splits beneficiaries
+    await Promise.all(
+      splits.map(async (split) => {
+        mockToken.transfer
+          .whenCalledWith(split.beneficiary, AMOUNT.mul(split.percent).div(maxSplitsPercent))
+          .returns(true);
+      }),
+    );
+
+    // Transfer leftover from splitsPayer to msg.sender
+    mockToken.transfer.whenCalledWith(caller.address, AMOUNT.div('2')).returns(true);
+
+    let tx = await jbSplitsPayerWithoutDefaultBeneficiary
+      .connect(caller)
+      .pay(
+        0,
+        mockToken.address,
+        AMOUNT,
+        DECIMALS,
+        ethers.constants.AddressZero,
+        MIN_RETURNED_TOKENS,
+        PREFER_CLAIMED_TOKENS,
+        MEMO,
+        METADATA,
+      );
+
+    await expect(tx).to.emit(jbSplitsPayerWithoutDefaultBeneficiary, 'Pay').withArgs(
+      0,
+      caller.address,
+      mockToken.address,
+      AMOUNT,
+      18,
+      AMOUNT.div('2'), //left over
+      MIN_RETURNED_TOKENS,
+      PREFER_CLAIMED_TOKENS,
+      MEMO,
+      METADATA,
+      caller.address,
+    );
+  });
+
+  it(`Should pay to split with a null amount and emit event`, async function () {
+    const { caller, jbSplitsPayer, mockJbSplitsStore } = await setup();
+
+    let splits = makeSplits();
+
+    await mockJbSplitsStore.mock.splitsOf
+      .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
+      .returns(splits);
+
+    let tx = await jbSplitsPayer
+      .connect(caller)
+      .pay(
+        PROJECT_ID,
+        ethToken,
+        0,
+        DECIMALS,
+        BENEFICIARY,
+        MIN_RETURNED_TOKENS,
+        PREFER_CLAIMED_TOKENS,
+        MEMO,
+        METADATA,
+        {
+          value: 0,
+        },
+      );
+
+    await expect(tx).to.changeEtherBalance(caller, 0); // Send then receive the amount (gas is not taken into account)
+
+    await expect(tx)
+      .to.emit(jbSplitsPayer, 'Pay')
+      .withArgs(
+        PROJECT_ID,
+        BENEFICIARY,
+        ethToken,
+        0,
+        DECIMALS,
+        0,
+        MIN_RETURNED_TOKENS,
+        PREFER_CLAIMED_TOKENS,
+        MEMO,
+        METADATA,
+        caller.address,
+      );
+  });
+
+  it(`Cannot send ETH with another token as argument`, async function () {
+    const { jbSplitsPayer, mockToken } = await setup();
+
+    await expect(
+      jbSplitsPayer.pay(
+        DEFAULT_PROJECT_ID,
+        mockToken.address,
+        AMOUNT,
+        DECIMALS,
+        BENEFICIARY,
+        MIN_RETURNED_TOKENS,
+        PREFER_CLAIMED_TOKENS,
+        MEMO,
+        METADATA,
+        {
+          value: AMOUNT,
+        },
+      ),
+    ).to.be.revertedWith(errors.NO_MSG_VALUE_ALLOWED);
+  });
+});

--- a/test/jb_eth_erc20_splits_payer_deployer/receive.test.js
+++ b/test/jb_eth_erc20_splits_payer_deployer/receive.test.js
@@ -1,0 +1,545 @@
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { makeSplits } from '../helpers/utils.js';
+
+import { deployMockContract } from '@ethereum-waffle/mock-contract';
+
+import errors from '../helpers/errors.json';
+import ierc20 from '../../artifacts/@openzeppelin/contracts/token/ERC20/ERC20.sol/ERC20.json';
+import jbAllocator from '../../artifacts/contracts/interfaces/IJBSplitAllocator.sol/IJBSplitAllocator.json';
+import jbDirectory from '../../artifacts/contracts/JBDirectory.sol/JBDirectory.json';
+import jbSplitsStore from '../../artifacts/contracts/JBSplitsStore.sol/JBSplitsStore.json';
+import jbTerminal from '../../artifacts/contracts/abstract/JBPayoutRedemptionPaymentTerminal.sol/JBPayoutRedemptionPaymentTerminal.json';
+
+describe('JBETHERC20SplitsPayer with Proxy::receive()', function () {
+  const DEFAULT_PROJECT_ID = 2;
+  const DEFAULT_SPLITS_PROJECT_ID = 3;
+  const DEFAULT_SPLITS_DOMAIN = 1;
+  const DEFAULT_SPLITS_GROUP = 1;
+  let DEFAULT_BENEFICIARY;
+  const DEFAULT_PREFER_CLAIMED_TOKENS = false;
+  const DEFAULT_MEMO = 'hello world';
+  const DEFAULT_METADATA = '0x69';
+
+  const PROJECT_ID = 69;
+  const AMOUNT = ethers.utils.parseEther('1.0');
+  const PREFER_ADD_TO_BALANCE = false;
+  const PREFER_CLAIMED_TOKENS = true;
+  const MIN_RETURNED_TOKENS = 1;
+  const MEMO = 'hi world';
+  const METADATA = '0x42';
+
+  let ethToken;
+  let maxSplitsPercent;
+
+  this.beforeAll(async function () {
+    let jbTokensFactory = await ethers.getContractFactory('JBTokens');
+    let jbTokens = await jbTokensFactory.deploy();
+
+    ethToken = await jbTokens.ETH();
+
+    let jbConstantsFactory = await ethers.getContractFactory('JBConstants');
+    let jbConstants = await jbConstantsFactory.deploy();
+
+    maxSplitsPercent = await jbConstants.SPLITS_TOTAL_PERCENT();
+  });
+
+  async function setup() {
+    let [
+      deployer,
+      owner,
+      caller,
+      beneficiaryOne,
+      beneficiaryTwo,
+      beneficiaryThree,
+      defaultBeneficiarySigner,
+      ...addrs
+    ] = await ethers.getSigners();
+
+    DEFAULT_BENEFICIARY = defaultBeneficiarySigner.address;
+
+    let mockJbDirectory = await deployMockContract(deployer, jbDirectory.abi);
+    let mockJbSplitsStore = await deployMockContract(deployer, jbSplitsStore.abi);
+    let mockJbTerminal = await deployMockContract(deployer, jbTerminal.abi);
+    let mockToken = await deployMockContract(deployer, ierc20.abi);
+
+    let jbSplitsPayerFactory = await ethers.getContractFactory(
+      'contracts/JBETHERC20SplitsPayer.sol:JBETHERC20SplitsPayer',
+    );
+
+    await mockJbSplitsStore.mock.directory.returns(mockJbDirectory.address);
+
+    let jbSplitsPayer = await jbSplitsPayerFactory.deploy(
+      DEFAULT_SPLITS_PROJECT_ID,
+      DEFAULT_SPLITS_DOMAIN,
+      DEFAULT_SPLITS_GROUP,
+      mockJbSplitsStore.address,
+      DEFAULT_PROJECT_ID,
+      DEFAULT_BENEFICIARY,
+      DEFAULT_PREFER_CLAIMED_TOKENS,
+      DEFAULT_MEMO,
+      DEFAULT_METADATA,
+      PREFER_ADD_TO_BALANCE,
+      owner.address,
+    );
+
+    return {
+      beneficiaryOne,
+      beneficiaryTwo,
+      beneficiaryThree,
+      defaultBeneficiarySigner,
+      deployer,
+      caller,
+      owner,
+      addrs,
+      mockToken,
+      mockJbDirectory,
+      mockJbTerminal,
+      mockJbSplitsStore,
+      jbSplitsPayer,
+      jbSplitsPayerFactory,
+    };
+  }
+
+  it(`Should send ETH towards allocator if set in split`, async function () {
+    const { deployer, caller, jbSplitsPayer, mockJbSplitsStore } = await setup();
+
+    let mockJbAllocator = await deployMockContract(deployer, jbAllocator.abi);
+
+    let splits = makeSplits({ projectId: PROJECT_ID, allocator: mockJbAllocator.address });
+
+    await mockJbSplitsStore.mock.splitsOf
+      .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
+      .returns(splits);
+
+    await Promise.all(
+      splits.map(async (split) => {
+        await mockJbAllocator.mock.allocate
+          .withArgs({
+            token: ethToken,
+            amount: AMOUNT.mul(split.percent).div(maxSplitsPercent),
+            decimals: 18,
+            projectId: DEFAULT_PROJECT_ID,
+            group: 0,
+            split: split,
+          })
+          .returns();
+      }),
+    );
+
+    let tx = await caller.sendTransaction({ to: jbSplitsPayer.address, value: AMOUNT });
+    await expect(tx).to.changeEtherBalance(mockJbAllocator, AMOUNT);
+  });
+
+  it(`Should send fund towards project terminal if project ID is set in split and add to balance if it is prefered`, async function () {
+    const { caller, jbSplitsPayer, mockJbSplitsStore, mockJbDirectory, mockJbTerminal } =
+      await setup();
+
+    let splits = makeSplits({ projectId: PROJECT_ID, preferAddToBalance: true });
+
+    await mockJbDirectory.mock.primaryTerminalOf
+      .withArgs(PROJECT_ID, ethToken)
+      .returns(mockJbTerminal.address);
+
+    await mockJbTerminal.mock.decimalsForToken.withArgs(ethToken).returns(18);
+
+    await Promise.all(
+      splits.map(async (split) => {
+        await mockJbTerminal.mock.addToBalanceOf
+          .withArgs(
+            split.projectId,
+            AMOUNT.mul(split.percent).div(maxSplitsPercent),
+            ethToken,
+            DEFAULT_MEMO,
+            DEFAULT_METADATA,
+          )
+          .returns();
+      }),
+    );
+
+    await mockJbSplitsStore.mock.splitsOf
+      .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
+      .returns(splits);
+
+    let tx = await caller.sendTransaction({ to: jbSplitsPayer.address, value: AMOUNT });
+    await expect(tx).to.changeEtherBalance(mockJbTerminal, AMOUNT);
+  });
+
+  it(`Should send fund towards project terminal if project ID is set in split, using pay with beneficiaries set in splits`, async function () {
+    const {
+      caller,
+      beneficiaryOne,
+      beneficiaryTwo,
+      jbSplitsPayer,
+      mockJbSplitsStore,
+      mockJbDirectory,
+      mockJbTerminal,
+    } = await setup();
+    let splits = makeSplits({
+      count: 2,
+      projectId: PROJECT_ID,
+      beneficiary: [beneficiaryOne.address, beneficiaryTwo.address],
+    });
+
+    await mockJbDirectory.mock.primaryTerminalOf
+      .withArgs(PROJECT_ID, ethToken)
+      .returns(mockJbTerminal.address);
+
+    await mockJbTerminal.mock.decimalsForToken.withArgs(ethToken).returns(18);
+
+    await Promise.all(
+      splits.map(async (split) => {
+        await mockJbTerminal.mock.pay
+          .withArgs(
+            split.projectId,
+            AMOUNT.mul(split.percent).div(maxSplitsPercent),
+            ethToken,
+            split.beneficiary,
+            0 /*hardcoded*/,
+            split.preferClaimed,
+            DEFAULT_MEMO,
+            DEFAULT_METADATA,
+          )
+          .returns(0); // Not used
+      }),
+    );
+
+    await mockJbSplitsStore.mock.splitsOf
+      .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
+      .returns(splits);
+
+    let tx = await caller.sendTransaction({ to: jbSplitsPayer.address, value: AMOUNT });
+    await expect(tx).to.changeEtherBalance(mockJbTerminal, AMOUNT);
+  });
+
+  it(`Should send fund towards project terminal if project ID is set in split, using pay with the default beneficiary if none is set in splits`, async function () {
+    const { caller, jbSplitsPayer, mockJbSplitsStore, mockJbDirectory, mockJbTerminal } =
+      await setup();
+
+    let splits = makeSplits({ projectId: PROJECT_ID });
+
+    await mockJbDirectory.mock.primaryTerminalOf
+      .withArgs(PROJECT_ID, ethToken)
+      .returns(mockJbTerminal.address);
+
+    await mockJbTerminal.mock.decimalsForToken.withArgs(ethToken).returns(18);
+
+    await Promise.all(
+      splits.map(async (split) => {
+        await mockJbTerminal.mock.pay
+          .withArgs(
+            split.projectId,
+            AMOUNT.mul(split.percent).div(maxSplitsPercent),
+            ethToken,
+            DEFAULT_BENEFICIARY,
+            0 /*hardcoded*/,
+            split.preferClaimed,
+            DEFAULT_MEMO,
+            DEFAULT_METADATA,
+          )
+          .returns(0); // Not used
+      }),
+    );
+
+    await mockJbSplitsStore.mock.splitsOf
+      .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
+      .returns(splits);
+
+    let tx = await caller.sendTransaction({ to: jbSplitsPayer.address, value: AMOUNT });
+    await expect(tx).to.changeEtherBalance(mockJbTerminal, AMOUNT);
+  });
+
+  it(`Should send fund directly to a beneficiary set in split, if no allocator or project ID is set in splits`, async function () {
+    const { caller, beneficiaryOne, beneficiaryTwo, jbSplitsPayer, mockJbSplitsStore } =
+      await setup();
+
+    let splits = makeSplits({
+      count: 2,
+      beneficiary: [beneficiaryOne.address, beneficiaryTwo.address],
+    });
+
+    await mockJbSplitsStore.mock.splitsOf
+      .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
+      .returns(splits);
+
+    let tx = await caller.sendTransaction({ to: jbSplitsPayer.address, value: AMOUNT });
+    await expect(tx).to.changeEtherBalance(
+      beneficiaryOne,
+      AMOUNT.mul(splits[0].percent).div(maxSplitsPercent),
+    );
+    await expect(tx).to.changeEtherBalance(
+      beneficiaryTwo,
+      AMOUNT.mul(splits[0].percent).div(maxSplitsPercent),
+    );
+  });
+
+  it(`Should send fund directly to the default beneficiary, if no allocator, project ID or beneficiary is set`, async function () {
+    const { caller, jbSplitsPayer, mockJbSplitsStore, defaultBeneficiarySigner } = await setup();
+
+    let splits = makeSplits();
+
+    await mockJbSplitsStore.mock.splitsOf
+      .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
+      .returns(splits);
+
+    let tx = await caller.sendTransaction({ to: jbSplitsPayer.address, value: AMOUNT });
+    await expect(tx).to.changeEtherBalance(defaultBeneficiarySigner, AMOUNT);
+  });
+
+  it(`Should send fund directly to the caller, if no allocator, project ID, beneficiary or default beneficiary is set`, async function () {
+    const { caller, jbSplitsPayerFactory, mockJbSplitsStore, owner } = await setup();
+
+    let jbSplitsPayerWithoutDefaultBeneficiary = await jbSplitsPayerFactory.deploy(
+      DEFAULT_SPLITS_PROJECT_ID,
+      DEFAULT_SPLITS_DOMAIN,
+      DEFAULT_SPLITS_GROUP,
+      mockJbSplitsStore.address,
+      DEFAULT_PROJECT_ID,
+      ethers.constants.AddressZero,
+      DEFAULT_PREFER_CLAIMED_TOKENS,
+      DEFAULT_MEMO,
+      DEFAULT_METADATA,
+      PREFER_ADD_TO_BALANCE,
+      owner.address,
+    );
+
+    let splits = makeSplits();
+
+    await mockJbSplitsStore.mock.splitsOf
+      .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
+      .returns(splits);
+
+    let tx = await caller.sendTransaction({
+      to: jbSplitsPayerWithoutDefaultBeneficiary.address,
+      value: AMOUNT,
+    });
+    await expect(tx).to.changeEtherBalance(caller, 0); // -AMOUNT then +AMOUNT, gas is not taken into account
+  });
+
+  it(`Should send eth leftover to project id if set, using pay`, async function () {
+    const {
+      caller,
+      jbSplitsPayer,
+      mockJbDirectory,
+      mockJbSplitsStore,
+      mockJbTerminal,
+      beneficiaryOne,
+      beneficiaryTwo,
+      beneficiaryThree,
+    } = await setup();
+
+    // 50% to beneficiaries
+    let splits = makeSplits({
+      count: 2,
+      beneficiary: [beneficiaryOne.address, beneficiaryTwo.address],
+      percent: maxSplitsPercent.div('4'),
+    });
+
+    await mockJbSplitsStore.mock.splitsOf
+      .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
+      .returns(splits);
+
+    await mockJbTerminal.mock.decimalsForToken.withArgs(ethToken).returns(18);
+
+    await mockJbDirectory.mock.primaryTerminalOf
+      .withArgs(DEFAULT_PROJECT_ID, ethToken)
+      .returns(mockJbTerminal.address);
+
+    await mockJbTerminal.mock.pay
+      .withArgs(
+        DEFAULT_PROJECT_ID,
+        AMOUNT.div('2'),
+        ethToken,
+        DEFAULT_BENEFICIARY,
+        0,
+        DEFAULT_PREFER_CLAIMED_TOKENS,
+        DEFAULT_MEMO,
+        DEFAULT_METADATA,
+      )
+      .returns(0); // Not used
+
+    let tx = await caller.sendTransaction({ to: jbSplitsPayer.address, value: AMOUNT });
+    await expect(tx).to.changeEtherBalance(
+      beneficiaryOne,
+      AMOUNT.mul(splits[0].percent).div(maxSplitsPercent),
+    );
+    await expect(tx).to.changeEtherBalance(
+      beneficiaryTwo,
+      AMOUNT.mul(splits[0].percent).div(maxSplitsPercent),
+    );
+    await expect(tx).to.changeEtherBalance(mockJbTerminal, AMOUNT.div(2));
+  });
+
+  it(`Should send eth leftover to project id if set, using addToBalance`, async function () {
+    const {
+      caller,
+      owner,
+      jbSplitsPayerFactory,
+      mockJbDirectory,
+      mockJbSplitsStore,
+      mockJbTerminal,
+      beneficiaryOne,
+      beneficiaryTwo,
+      beneficiaryThree,
+    } = await setup();
+
+    let jbSplitsPayerPreferAddToBalance = await jbSplitsPayerFactory.deploy(
+      DEFAULT_SPLITS_PROJECT_ID,
+      DEFAULT_SPLITS_DOMAIN,
+      DEFAULT_SPLITS_GROUP,
+      mockJbSplitsStore.address,
+      DEFAULT_PROJECT_ID,
+      DEFAULT_BENEFICIARY,
+      DEFAULT_PREFER_CLAIMED_TOKENS,
+      DEFAULT_MEMO,
+      DEFAULT_METADATA,
+      true,
+      owner.address,
+    );
+
+    // 50% to beneficiaries
+    let splits = makeSplits({
+      count: 2,
+      beneficiary: [beneficiaryOne.address, beneficiaryTwo.address],
+      percent: maxSplitsPercent.div('4'),
+    });
+
+    await mockJbSplitsStore.mock.splitsOf
+      .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
+      .returns(splits);
+
+    await mockJbTerminal.mock.decimalsForToken.withArgs(ethToken).returns(18);
+
+    await mockJbDirectory.mock.primaryTerminalOf
+      .withArgs(DEFAULT_PROJECT_ID, ethToken)
+      .returns(mockJbTerminal.address);
+
+    await mockJbTerminal.mock.addToBalanceOf
+      .withArgs(DEFAULT_PROJECT_ID, AMOUNT.div('2'), ethToken, DEFAULT_MEMO, DEFAULT_METADATA)
+      .returns();
+
+    let tx = await caller.sendTransaction({
+      to: jbSplitsPayerPreferAddToBalance.address,
+      value: AMOUNT,
+    });
+    await expect(tx).to.changeEtherBalance(
+      beneficiaryOne,
+      AMOUNT.mul(splits[0].percent).div(maxSplitsPercent),
+    );
+    await expect(tx).to.changeEtherBalance(
+      beneficiaryTwo,
+      AMOUNT.mul(splits[0].percent).div(maxSplitsPercent),
+    );
+    await expect(tx).to.changeEtherBalance(mockJbTerminal, AMOUNT.div(2));
+  });
+
+  it(`Should send eth leftover to beneficiary if no project id set`, async function () {
+    const {
+      caller,
+      owner,
+      jbSplitsPayerFactory,
+      mockJbSplitsStore,
+      mockJbTerminal,
+      beneficiaryOne,
+      beneficiaryTwo,
+      beneficiaryThree,
+    } = await setup();
+
+    let jbSplitsPayer = await jbSplitsPayerFactory.deploy(
+      DEFAULT_SPLITS_PROJECT_ID,
+      DEFAULT_SPLITS_DOMAIN,
+      DEFAULT_SPLITS_GROUP,
+      mockJbSplitsStore.address,
+      0,
+      beneficiaryThree.address,
+      DEFAULT_PREFER_CLAIMED_TOKENS,
+      DEFAULT_MEMO,
+      DEFAULT_METADATA,
+      true,
+      owner.address,
+    );
+    // 50% to beneficiaries
+    let splits = makeSplits({
+      count: 2,
+      beneficiary: [beneficiaryOne.address, beneficiaryTwo.address],
+      percent: maxSplitsPercent.div('4'),
+    });
+
+    await mockJbSplitsStore.mock.splitsOf
+      .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
+      .returns(splits);
+
+    await mockJbTerminal.mock.decimalsForToken.withArgs(ethToken).returns(18);
+
+    await mockJbTerminal.mock.pay
+      .withArgs(
+        0,
+        AMOUNT.div('2'),
+        ethToken,
+        beneficiaryThree.address,
+        MIN_RETURNED_TOKENS,
+        PREFER_CLAIMED_TOKENS,
+        MEMO,
+        METADATA,
+      )
+      .returns(0); // Not used
+
+    let tx = await caller.sendTransaction({ to: jbSplitsPayer.address, value: AMOUNT });
+    await expect(tx).to.changeEtherBalance(beneficiaryThree, AMOUNT.div('2'));
+  });
+
+  it(`Should send eth leftover to the caller if no project id nor beneficiary is set`, async function () {
+    const {
+      caller,
+      owner,
+      jbSplitsPayerFactory,
+      mockJbSplitsStore,
+      mockJbTerminal,
+      beneficiaryOne,
+      beneficiaryTwo,
+      beneficiaryThree,
+    } = await setup();
+
+    let jbSplitsPayer = await jbSplitsPayerFactory.deploy(
+      DEFAULT_SPLITS_PROJECT_ID,
+      DEFAULT_SPLITS_DOMAIN,
+      DEFAULT_SPLITS_GROUP,
+      mockJbSplitsStore.address,
+      0,
+      ethers.constants.AddressZero,
+      DEFAULT_PREFER_CLAIMED_TOKENS,
+      DEFAULT_MEMO,
+      DEFAULT_METADATA,
+      true,
+      owner.address,
+    );
+    // 50% to beneficiaries
+    let splits = makeSplits({
+      count: 2,
+      beneficiary: [beneficiaryOne.address, beneficiaryTwo.address],
+      percent: maxSplitsPercent.div('4'),
+    });
+
+    await mockJbSplitsStore.mock.splitsOf
+      .withArgs(DEFAULT_SPLITS_PROJECT_ID, DEFAULT_SPLITS_DOMAIN, DEFAULT_SPLITS_GROUP)
+      .returns(splits);
+
+    await mockJbTerminal.mock.decimalsForToken.withArgs(ethToken).returns(18);
+
+    await mockJbTerminal.mock.pay
+      .withArgs(
+        0,
+        AMOUNT.div('2'),
+        ethToken,
+        beneficiaryThree.address,
+        MIN_RETURNED_TOKENS,
+        PREFER_CLAIMED_TOKENS,
+        MEMO,
+        METADATA,
+      )
+      .returns(0); // Not used
+
+    let tx = await caller.sendTransaction({ to: jbSplitsPayer.address, value: AMOUNT });
+    await expect(tx).to.changeEtherBalance(caller, AMOUNT.div('-2'));
+  });
+});

--- a/test/jb_eth_erc20_splits_payer_deployer/receive.test.js
+++ b/test/jb_eth_erc20_splits_payer_deployer/receive.test.js
@@ -63,17 +63,37 @@ describe('JBETHERC20SplitsPayer with Proxy::receive()', function () {
     let mockJbTerminal = await deployMockContract(deployer, jbTerminal.abi);
     let mockToken = await deployMockContract(deployer, ierc20.abi);
 
-    let jbSplitsPayerFactory = await ethers.getContractFactory(
-      'contracts/JBETHERC20SplitsPayer.sol:JBETHERC20SplitsPayer',
-    );
-
     await mockJbSplitsStore.mock.directory.returns(mockJbDirectory.address);
 
-    let jbSplitsPayer = await jbSplitsPayerFactory.deploy(
+    let jbSplitsPayerDeployerFactory = await ethers.getContractFactory(
+      'contracts/JBETHERC20SplitsPayerDeployer.sol:JBETHERC20SplitsPayerDeployer',
+    );
+
+    let jbSplitsPayerDeployer = await jbSplitsPayerDeployerFactory.deploy(
+      mockJbSplitsStore.address,
+    );
+
+    let jbSplitsPayerFactory = await ethers.getContractFactory('JBETHERC20SplitsPayer');
+
+    let jbSplitsPayer = jbSplitsPayerFactory.attach(
+      await jbSplitsPayerDeployer.callStatic.deploySplitsPayer(
+        DEFAULT_SPLITS_PROJECT_ID,
+        DEFAULT_SPLITS_DOMAIN,
+        DEFAULT_SPLITS_GROUP,
+        DEFAULT_PROJECT_ID,
+        DEFAULT_BENEFICIARY,
+        DEFAULT_PREFER_CLAIMED_TOKENS,
+        DEFAULT_MEMO,
+        DEFAULT_METADATA,
+        PREFER_ADD_TO_BALANCE,
+        owner.address,
+      ),
+    );
+
+    await jbSplitsPayerDeployer.deploySplitsPayer(
       DEFAULT_SPLITS_PROJECT_ID,
       DEFAULT_SPLITS_DOMAIN,
       DEFAULT_SPLITS_GROUP,
-      mockJbSplitsStore.address,
       DEFAULT_PROJECT_ID,
       DEFAULT_BENEFICIARY,
       DEFAULT_PREFER_CLAIMED_TOKENS,
@@ -82,7 +102,6 @@ describe('JBETHERC20SplitsPayer with Proxy::receive()', function () {
       PREFER_ADD_TO_BALANCE,
       owner.address,
     );
-
     return {
       beneficiaryOne,
       beneficiaryTwo,
@@ -98,6 +117,7 @@ describe('JBETHERC20SplitsPayer with Proxy::receive()', function () {
       mockJbSplitsStore,
       jbSplitsPayer,
       jbSplitsPayerFactory,
+      jbSplitsPayerDeployer,
     };
   }
 
@@ -287,13 +307,28 @@ describe('JBETHERC20SplitsPayer with Proxy::receive()', function () {
   });
 
   it(`Should send fund directly to the caller, if no allocator, project ID, beneficiary or default beneficiary is set`, async function () {
-    const { caller, jbSplitsPayerFactory, mockJbSplitsStore, owner } = await setup();
+    const { caller, jbSplitsPayerFactory, jbSplitsPayerDeployer, mockJbSplitsStore, owner } =
+      await setup();
 
-    let jbSplitsPayerWithoutDefaultBeneficiary = await jbSplitsPayerFactory.deploy(
+    let jbSplitsPayerWithoutDefaultBeneficiary = jbSplitsPayerFactory.attach(
+      await jbSplitsPayerDeployer.callStatic.deploySplitsPayer(
+        DEFAULT_SPLITS_PROJECT_ID,
+        DEFAULT_SPLITS_DOMAIN,
+        DEFAULT_SPLITS_GROUP,
+        DEFAULT_PROJECT_ID,
+        ethers.constants.AddressZero,
+        DEFAULT_PREFER_CLAIMED_TOKENS,
+        DEFAULT_MEMO,
+        DEFAULT_METADATA,
+        PREFER_ADD_TO_BALANCE,
+        owner.address,
+      ),
+    );
+
+    await jbSplitsPayerDeployer.deploySplitsPayer(
       DEFAULT_SPLITS_PROJECT_ID,
       DEFAULT_SPLITS_DOMAIN,
       DEFAULT_SPLITS_GROUP,
-      mockJbSplitsStore.address,
       DEFAULT_PROJECT_ID,
       ethers.constants.AddressZero,
       DEFAULT_PREFER_CLAIMED_TOKENS,
@@ -375,6 +410,7 @@ describe('JBETHERC20SplitsPayer with Proxy::receive()', function () {
       caller,
       owner,
       jbSplitsPayerFactory,
+      jbSplitsPayerDeployer,
       mockJbDirectory,
       mockJbSplitsStore,
       mockJbTerminal,
@@ -383,11 +419,25 @@ describe('JBETHERC20SplitsPayer with Proxy::receive()', function () {
       beneficiaryThree,
     } = await setup();
 
-    let jbSplitsPayerPreferAddToBalance = await jbSplitsPayerFactory.deploy(
+    let jbSplitsPayerPreferAddToBalance = jbSplitsPayerFactory.attach(
+      await jbSplitsPayerDeployer.callStatic.deploySplitsPayer(
+        DEFAULT_SPLITS_PROJECT_ID,
+        DEFAULT_SPLITS_DOMAIN,
+        DEFAULT_SPLITS_GROUP,
+        DEFAULT_PROJECT_ID,
+        DEFAULT_BENEFICIARY,
+        DEFAULT_PREFER_CLAIMED_TOKENS,
+        DEFAULT_MEMO,
+        DEFAULT_METADATA,
+        true,
+        owner.address,
+      ),
+    );
+
+    await jbSplitsPayerDeployer.deploySplitsPayer(
       DEFAULT_SPLITS_PROJECT_ID,
       DEFAULT_SPLITS_DOMAIN,
       DEFAULT_SPLITS_GROUP,
-      mockJbSplitsStore.address,
       DEFAULT_PROJECT_ID,
       DEFAULT_BENEFICIARY,
       DEFAULT_PREFER_CLAIMED_TOKENS,
@@ -438,6 +488,7 @@ describe('JBETHERC20SplitsPayer with Proxy::receive()', function () {
       caller,
       owner,
       jbSplitsPayerFactory,
+      jbSplitsPayerDeployer,
       mockJbSplitsStore,
       mockJbTerminal,
       beneficiaryOne,
@@ -445,11 +496,25 @@ describe('JBETHERC20SplitsPayer with Proxy::receive()', function () {
       beneficiaryThree,
     } = await setup();
 
-    let jbSplitsPayer = await jbSplitsPayerFactory.deploy(
+    let jbSplitsPayer = jbSplitsPayerFactory.attach(
+      await jbSplitsPayerDeployer.callStatic.deploySplitsPayer(
+        DEFAULT_SPLITS_PROJECT_ID,
+        DEFAULT_SPLITS_DOMAIN,
+        DEFAULT_SPLITS_GROUP,
+        0,
+        beneficiaryThree.address,
+        DEFAULT_PREFER_CLAIMED_TOKENS,
+        DEFAULT_MEMO,
+        DEFAULT_METADATA,
+        true,
+        owner.address,
+      ),
+    );
+
+    await jbSplitsPayerDeployer.deploySplitsPayer(
       DEFAULT_SPLITS_PROJECT_ID,
       DEFAULT_SPLITS_DOMAIN,
       DEFAULT_SPLITS_GROUP,
-      mockJbSplitsStore.address,
       0,
       beneficiaryThree.address,
       DEFAULT_PREFER_CLAIMED_TOKENS,
@@ -458,6 +523,7 @@ describe('JBETHERC20SplitsPayer with Proxy::receive()', function () {
       true,
       owner.address,
     );
+
     // 50% to beneficiaries
     let splits = makeSplits({
       count: 2,
@@ -493,6 +559,7 @@ describe('JBETHERC20SplitsPayer with Proxy::receive()', function () {
       caller,
       owner,
       jbSplitsPayerFactory,
+      jbSplitsPayerDeployer,
       mockJbSplitsStore,
       mockJbTerminal,
       beneficiaryOne,
@@ -500,11 +567,25 @@ describe('JBETHERC20SplitsPayer with Proxy::receive()', function () {
       beneficiaryThree,
     } = await setup();
 
-    let jbSplitsPayer = await jbSplitsPayerFactory.deploy(
+    let jbSplitsPayer = jbSplitsPayerFactory.attach(
+      await jbSplitsPayerDeployer.callStatic.deploySplitsPayer(
+        DEFAULT_SPLITS_PROJECT_ID,
+        DEFAULT_SPLITS_DOMAIN,
+        DEFAULT_SPLITS_GROUP,
+        0,
+        ethers.constants.AddressZero,
+        DEFAULT_PREFER_CLAIMED_TOKENS,
+        DEFAULT_MEMO,
+        DEFAULT_METADATA,
+        true,
+        owner.address,
+      ),
+    );
+
+    await jbSplitsPayerDeployer.deploySplitsPayer(
       DEFAULT_SPLITS_PROJECT_ID,
       DEFAULT_SPLITS_DOMAIN,
       DEFAULT_SPLITS_GROUP,
-      mockJbSplitsStore.address,
       0,
       ethers.constants.AddressZero,
       DEFAULT_PREFER_CLAIMED_TOKENS,
@@ -513,6 +594,7 @@ describe('JBETHERC20SplitsPayer with Proxy::receive()', function () {
       true,
       owner.address,
     );
+
     // 50% to beneficiaries
     let splits = makeSplits({
       count: 2,


### PR DESCRIPTION
# Description

Migrate the current redeployment pattern from splits and project payer to OZ Clones.

## Limitations & risks

Deployment cost is lowered, while contract interaction is marginally higher.
To reduce one storage access cost, splits store and directory are now immutable (in the *unlikely* event we'd redeploy them, these contracts would have to be redeployed too)

# Check-list
- [x] Tests are covering the new feature
- [x] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [x] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [x] I have run the test locally (and they pass)
- [x] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:
JBETHERC20ProjectPayer & JBETHERC20ProjectPayerDeployer
JBETHERC20SplitsPayer & JBETHERC20SplitsPayerDeployer

- Indirectly:
Terminal