### PR TITLE
fix: project&script payer deployment in old scripts

### DIFF
--- a/deploy/1.js
+++ b/deploy/1.js
@@ -47,19 +47,6 @@ module.exports = async ({ deployments, getChainId }) => {
 
   console.log({ multisigAddress, protocolProjectStartsAtOrAfter });
 
-  // Deploy a JBETHERC20ProjectPayerDeployer contract.
-  await deploy('JBETHERC20ProjectPayerDeployer', {
-    ...baseDeployArgs,
-    args: [],
-  });
-
-  // Deploy a JBETHERC20SplitsPayerDeployer contract.
-  await deploy('JBETHERC20SplitsPayerDeployer', {
-    ...baseDeployArgs,
-    contract: 'contracts/JBETHERC20SplitsPayerDeployer.sol:JBETHERC20SplitsPayerDeployer',
-    args: [],
-  });
-
   // Deploy a JBOperatorStore contract.
   const JBOperatorStore = await deploy('JBOperatorStore', {
     ...baseDeployArgs,
@@ -176,6 +163,19 @@ module.exports = async ({ deployments, getChainId }) => {
     ],
   });
 
+  // Deploy a JBETHERC20ProjectPayerDeployer contract.
+  await deploy('JBETHERC20ProjectPayerDeployer', {
+    ...baseDeployArgs,
+    args: [JBDirectory.address],
+  });
+
+  // Deploy a JBETHERC20SplitsPayerDeployer contract.
+  await deploy('JBETHERC20SplitsPayerDeployer', {
+    ...baseDeployArgs,
+    contract: 'contracts/JBETHERC20SplitsPayerDeployer.sol:JBETHERC20SplitsPayerDeployer',
+    args: [JBSplitStore.address],
+  });
+
   // Get a reference to an existing ETH/USD feed.
   const usdEthFeed = await jbPricesContract.connect(deployer).feedFor(USD, ETH);
 
@@ -220,21 +220,21 @@ module.exports = async ({ deployments, getChainId }) => {
   // Deploy a JB1DayReconfigurationBufferBallot.
   await deploy('JB1DayReconfigurationBufferBallot', {
     ...baseDeployArgs,
-    contract: "contracts/JBReconfigurationBufferBallot.sol:JBReconfigurationBufferBallot",
+    contract: 'contracts/JBReconfigurationBufferBallot.sol:JBReconfigurationBufferBallot',
     args: [86400],
   });
 
   // Deploy a JB3DayReconfigurationBufferBallot.
   const JB3DayReconfigurationBufferBallot = await deploy('JB3DayReconfigurationBufferBallot', {
     ...baseDeployArgs,
-    contract: "contracts/JBReconfigurationBufferBallot.sol:JBReconfigurationBufferBallot",
+    contract: 'contracts/JBReconfigurationBufferBallot.sol:JBReconfigurationBufferBallot',
     args: [259200],
   });
 
   // Deploy a JB7DayReconfigurationBufferBallot.
   await deploy('JB7DayReconfigurationBufferBallot', {
     ...baseDeployArgs,
-    contract: "contracts/JBReconfigurationBufferBallot.sol:JBReconfigurationBufferBallot",
+    contract: 'contracts/JBReconfigurationBufferBallot.sol:JBReconfigurationBufferBallot',
     args: [604800],
   });
 
@@ -300,7 +300,6 @@ module.exports = async ({ deployments, getChainId }) => {
       splits: splits,
     };
 
-
     console.log('Deploying protocol project...');
 
     await jbControllerContract.connect(deployer).launchProjectFor(
@@ -345,11 +344,11 @@ module.exports = async ({ deployments, getChainId }) => {
 
       /*mustStartAtOrAfter*/ ethers.BigNumber.from(protocolProjectStartsAtOrAfter),
 
-      /*groupedSplits*/[groupedSplits],
+      /*groupedSplits*/ [groupedSplits],
 
-      /*fundAccessConstraints*/[],
+      /*fundAccessConstraints*/ [],
 
-      /*terminals*/[JBETHPaymentTerminal.address],
+      /*terminals*/ [JBETHPaymentTerminal.address],
 
       /*memo*/ '',
     );

--- a/deploy/v3_1.js
+++ b/deploy/v3_1.js
@@ -47,19 +47,6 @@ module.exports = async ({ deployments, getChainId }) => {
 
   console.log({ multisigAddress, protocolProjectStartsAtOrAfter });
 
-  // Deploy a JBETHERC20ProjectPayerDeployer contract.
-  await deploy('JBETHERC20ProjectPayerDeployer', {
-    ...baseDeployArgs,
-    args: [],
-  });
-
-  // Deploy a JBETHERC20SplitsPayerDeployer contract.
-  await deploy('JBETHERC20SplitsPayerDeployer', {
-    ...baseDeployArgs,
-    contract: 'contracts/JBETHERC20SplitsPayerDeployer.sol:JBETHERC20SplitsPayerDeployer',
-    args: [],
-  });
-
   // Deploy a JBOperatorStore contract.
   const JBOperatorStore = await deploy('JBOperatorStore', {
     ...baseDeployArgs,
@@ -189,6 +176,19 @@ module.exports = async ({ deployments, getChainId }) => {
       JBSingleTokenPaymentTerminalStore.address,
       multisigAddress,
     ],
+  });
+
+  // Deploy a JBETHERC20ProjectPayerDeployer contract.
+  await deploy('JBETHERC20ProjectPayerDeployer', {
+    ...baseDeployArgs,
+    args: [JBDirectory.address],
+  });
+
+  // Deploy a JBETHERC20SplitsPayerDeployer contract.
+  await deploy('JBETHERC20SplitsPayerDeployer', {
+    ...baseDeployArgs,
+    contract: 'contracts/JBETHERC20SplitsPayerDeployer.sol:JBETHERC20SplitsPayerDeployer',
+    args: [JBSplitStore.address],
   });
 
   // Get a reference to an existing ETH/USD feed.


### PR DESCRIPTION
Previous deployment scripts was using the now deprecated constructor signature for project and split payer deployer.