### PR TITLE
Permit2 support for ERC20 Terminals

### DIFF
--- a/contracts/JBERC20PaymentTerminal3_1_3.sol
+++ b/contracts/JBERC20PaymentTerminal3_1_3.sol
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.16;
+
+import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import {IERC20Metadata} from '@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol';
+import {SafeERC20} from '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
+import {JBPayoutRedemptionPaymentTerminal3_1_2, JBTokens} from './abstract/JBPayoutRedemptionPaymentTerminal3_1_2.sol';
+import {IJBDirectory} from './interfaces/IJBDirectory.sol';
+import {IJBOperatorStore} from './interfaces/IJBOperatorStore.sol';
+import {IJBProjects} from './interfaces/IJBProjects.sol';
+import {IJBSplitsStore} from './interfaces/IJBSplitsStore.sol';
+import {IJBPrices} from './interfaces/IJBPrices.sol';
+import {JBSingleAllowanceData} from './structs/JBSingleAllowanceData.sol';
+import {IPermit2, IAllowanceTransfer} from 'permit2/src/interfaces/IPermit2.sol';
+
+/// @notice Manages the inflows and outflows of an ERC-20 token.
+contract JBERC20PaymentTerminal3_1_2 is JBPayoutRedemptionPaymentTerminal3_1_2 {
+  using SafeERC20 for IERC20;
+
+  //*********************************************************************//
+  // --------------------------- custom errors ------------------------- //
+  //*********************************************************************//
+  error PERMIT_ALLOWANCE_NOT_ENOUGH(uint256 _transactionAmount, uint256 _permitAllowance);
+
+  //*********************************************************************//
+  // ---------------- public immutable stored properties --------------- //
+  //*********************************************************************//
+  IPermit2 immutable PERMIT2;
+
+  //*********************************************************************//
+  // -------------------------- internal views ------------------------- //
+  //*********************************************************************//
+
+  /// @notice Checks the balance of tokens in this contract.
+  /// @return The contract's balance, as a fixed point number with the same amount of decimals as this terminal.
+  function _balance() internal view override returns (uint256) {
+    return IERC20(token).balanceOf(address(this));
+  }
+
+  //*********************************************************************//
+  // -------------------------- constructor ---------------------------- //
+  //*********************************************************************//
+
+  /// @param _token The token that this terminal manages.
+  /// @param _currency The currency that this terminal's token adheres to for price feeds.
+  /// @param _baseWeightCurrency The currency to base token issuance on.
+  /// @param _payoutSplitsGroup The group that denotes payout splits from this terminal in the splits store.
+  /// @param _operatorStore A contract storing operator assignments.
+  /// @param _projects A contract which mints ERC-721's that represent project ownership and transfers.
+  /// @param _directory A contract storing directories of terminals and controllers for each project.
+  /// @param _splitsStore A contract that stores splits for each project.
+  /// @param _prices A contract that exposes price feeds.
+  /// @param _store A contract that stores the terminal's data.
+  /// @param _owner The address that will own this contract.
+  constructor(
+    IERC20Metadata _token,
+    uint256 _currency,
+    uint256 _baseWeightCurrency,
+    uint256 _payoutSplitsGroup,
+    IJBOperatorStore _operatorStore,
+    IJBProjects _projects,
+    IJBDirectory _directory,
+    IJBSplitsStore _splitsStore,
+    IJBPrices _prices,
+    address _store,
+    address _owner,
+    IPermit2 _permit2
+  )
+    JBPayoutRedemptionPaymentTerminal3_1_2(
+      address(_token),
+      _token.decimals(),
+      _currency,
+      _baseWeightCurrency,
+      _payoutSplitsGroup,
+      _operatorStore,
+      _projects,
+      _directory,
+      _splitsStore,
+      _prices,
+      _store,
+      _owner
+    )
+  // solhint-disable-next-line no-empty-blocks
+  {
+    PERMIT2 = _permit2;
+  }
+
+  //*********************************************************************//
+  // ----------------------- public transactions ----------------------- //
+  //*********************************************************************//
+
+  /// @notice Contribute tokens to a project and sets an allowance for this terminal (using Permit2).
+  /// @param _projectId The ID of the project being paid.
+  /// @param _amount The amount of terminal tokens being received, as a fixed point number with the same amount of decimals as this terminal. If this terminal's token is ETH, this is ignored and msg.value is used in its place.
+  /// @param _token The token being paid. This terminal ignores this property since it only manages one token.
+  /// @param _beneficiary The address to mint tokens for and pass along to the funding cycle's data source and delegate.
+  /// @param _minReturnedTokens The minimum number of project tokens expected in return, as a fixed point number with the same amount of decimals as this terminal.
+  /// @param _preferClaimedTokens A flag indicating whether the request prefers to mint project tokens into the beneficiaries wallet rather than leaving them unclaimed. This is only possible if the project has an attached token contract. Leaving them unclaimed saves gas.
+  /// @param _memo A memo to pass along to the emitted event, and passed along the the funding cycle's data source and delegate.  A data source can alter the memo before emitting in the event and forwarding to the delegate.
+  /// @param _metadata Bytes to send along to the data source, delegate, and emitted event, if provided.
+  /// @param _allowance The allowance to set for this terminal (using Permit2).
+  /// @return The number of tokens minted for the beneficiary, as a fixed point number with 18 decimals.
+  function payAndSetAllowance(
+    uint256 _projectId,
+    uint256 _amount,
+    address _token,
+    address _beneficiary,
+    uint256 _minReturnedTokens,
+    bool _preferClaimedTokens,
+    string calldata _memo,
+    bytes calldata _metadata,
+    JBSingleAllowanceData calldata _allowance
+  ) external virtual returns (uint256) {
+    // If the `_allowance.amount` is less than `_amount` then
+    // setting the permit will still not result in a succeful payment
+    if (_amount < _allowance.amount) revert PERMIT_ALLOWANCE_NOT_ENOUGH(_amount, _allowance.amount);
+    // Get allowance to `spend` tokens for the sender
+    _permitAllowance(_allowance);
+    // Continue with the regular pay flow
+    return
+      pay(
+        _projectId,
+        _amount,
+        _token,
+        _beneficiary,
+        _minReturnedTokens,
+        _preferClaimedTokens,
+        _memo,
+        _metadata
+      );
+  }
+
+  /// @notice Receives funds belonging to the specified project.
+  /// @param _projectId The ID of the project to which the funds received belong.
+  /// @param _amount The amount of tokens to add, as a fixed point number with the same number of decimals as this terminal. If this is an ETH terminal, this is ignored and msg.value is used instead.
+  /// @param _token The token being paid. This terminal ignores this property since it only manages one currency.
+  /// @param _shouldRefundHeldFees A flag indicating if held fees should be refunded based on the amount being added.
+  /// @param _memo A memo to pass along to the emitted event.
+  /// @param _metadata Extra data to pass along to the emitted event.
+  /// @param _allowance The allowance to set for this terminal (using Permit2).
+  function addToBalanceOfAndSetAllowance(
+    uint256 _projectId,
+    uint256 _amount,
+    address _token,
+    bool _shouldRefundHeldFees,
+    string calldata _memo,
+    bytes calldata _metadata,
+    JBSingleAllowanceData calldata _allowance
+  ) external virtual {
+    // If the `_allowance.amount` is less than `_amount` then
+    // setting the permit will still not result in a succeful payment
+    if (_amount < _allowance.amount) revert PERMIT_ALLOWANCE_NOT_ENOUGH(_amount, _allowance.amount);
+    // Get allowance to `spend` tokens for the user
+    _permitAllowance(_allowance);
+    // Continue with the regular addToBalanceOf flow
+    return addToBalanceOf(_projectId, _amount, _token, _shouldRefundHeldFees, _memo, _metadata);
+  }
+
+  //*********************************************************************//
+  // ---------------------- internal transactions ---------------------- //
+  //*********************************************************************//
+
+  /**
+   * @notice Gets allowance
+   * @param _allowance the allowance to get using permit2
+   */
+  function _permitAllowance(JBSingleAllowanceData calldata _allowance) internal {
+    // Use Permit2 to set the allowance
+    PERMIT2.permit(
+      msg.sender,
+      IAllowanceTransfer.PermitSingle({
+        details: IAllowanceTransfer.PermitDetails({
+          token: address(token),
+          amount: _allowance.amount,
+          expiration: _allowance.expiration,
+          nonce: _allowance.nonce
+        }),
+        spender: address(this),
+        sigDeadline: _allowance.sigDeadline
+      }),
+      _allowance.signature
+    );
+  }
+
+  /// @notice Transfers tokens.
+  /// @param _from The address from which the transfer should originate.
+  /// @param _to The address to which the transfer should go.
+  /// @param _amount The amount of the transfer, as a fixed point number with the same number of decimals as this terminal.
+  function _transferFrom(address _from, address payable _to, uint256 _amount) internal override {
+    // If this terminal is the sender we send the tokens directly
+    if (_from == address(this)) return IERC20(token).safeTransfer(_to, _amount);
+
+    // Get the approval that the `_from` has given us
+    // If we have enough direct approval we use this method
+    uint256 _approvalAmount = IERC20(token).allowance(address(this), address(_from));
+    if (_approvalAmount >= _amount) return IERC20(token).safeTransferFrom(_from, _to, _amount);
+
+    // Otherwise we attempt to use the PERMIT2 method
+    // TODO: Should we add safeCast for casting 256 to 160?
+    PERMIT2.transferFrom(_from, _to, uint160(_amount), address(token));
+  }
+
+  /// @notice Logic to be triggered before transferring tokens from this terminal.
+  /// @param _to The address to which the transfer is going.
+  /// @param _amount The amount of the transfer, as a fixed point number with the same number of decimals as this terminal.
+  function _beforeTransferTo(address _to, uint256 _amount) internal override {
+    IERC20(token).safeIncreaseAllowance(_to, _amount);
+  }
+
+  /// @notice Logic to be triggered if a transfer should be undone
+  /// @param _to The address to which the transfer went.
+  /// @param _amount The amount of the transfer, as a fixed point number with the same number of decimals as this terminal.
+  function _cancelTransferTo(address _to, uint256 _amount) internal override {
+    IERC20(token).safeDecreaseAllowance(_to, _amount);
+  }
+}

--- a/contracts/structs/JBSingleAllowanceData.sol
+++ b/contracts/structs/JBSingleAllowanceData.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @custom:member sigDeadline deadline on the permit signature
+/// @custom:member amount the maximum amount allowed to spend
+/// @custom:member expiration timestamp at which a spender's token allowances become invalid
+/// @custom:member nonce an incrementing value indexed per owner,token,and spender for each signature
+/// @custom:member signature the signature over the permit data. Supports EOA signatures, compact signatures defined by EIP-2098, and contract signatures defined by EIP-1271
+struct JBSingleAllowanceData {
+  uint256 sigDeadline;
+  uint160 amount;
+  uint48 expiration;
+  uint48 nonce;
+  bytes signature;
+}

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
   "license": "MIT",
   "dependencies": {
     "@chainlink/contracts": "^0.1.6",
+    "@openzeppelin/contracts": "^4.5.0-rc.0",
     "@paulrberg/contracts": "^3.4.0",
-    "@openzeppelin/contracts": "^4.5.0-rc.0"
+    "permit2": "https://github.com/Uniswap/permit2"
   },
   "devDependencies": {
     "@defi-wonderland/smock": "^2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8310,6 +8310,10 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
+"permit2@https://github.com/Uniswap/permit2":
+  version "0.0.0"
+  resolved "https://github.com/Uniswap/permit2#576f549a7351814f112edcc42f3f8472d1712673"
+
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"


### PR DESCRIPTION
Adds Permit2 support to terminals to improve the UX. Users will no longer need to do two separate transactions (Approve and Pay/AddToBalance), instead they can use Permit2 to give approval in the same transaction. 

(This only works if they have given the Permit2 contract approval to spend the tokens)

TODO: 
- [ ] Write tests
- [ ] Create interface for Allowance methods
- [ ] Add interface to ERC165
- [ ] SafeCast `uint256` to `uint160` (?)